### PR TITLE
Make twFile more robust when TiddlySaver.jar missing.

### DIFF
--- a/java/TiddlySaver.java
+++ b/java/TiddlySaver.java
@@ -8,7 +8,19 @@ import java.io.FileWriter;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import netscape.javascript.*;
+
 public class TiddlySaver extends java.applet.Applet {
+  // This method is automatically called when the applet is started.
+  // Sets a flag in JavaScript land to:
+  //   A. Provide a safe way to check availability of the tiddlysaver applet.
+  //   B. Identify the applet version (to help avoid cache confusion).
+  public void init()
+  {
+      JSObject window = JSObject.getWindow(this);
+      window.eval("$.twFile.tiddlySaverVersion = 1");
+  }
+
   public String loadFile(final String filename, final String charset) {
 	return (String)AccessController.doPrivileged(new PrivilegedAction() {
 	    public Object run() {		


### PR DESCRIPTION
Browsers tend to freeze when the TiddlySaver DOM applet node is
accessed but the applet is missing/fails to load. (Windows + JRE 1.6)
Sample: http://jsfiddle.net/nbtfh/4/

This patch allows twFile to degrade to an alternate driver, or at least
fail gracefully without freezing the browser.

These changes were made to make the TiddlySaver driver more stable:
- Added init() method to applet that automatically sets
  $.twFile.tiddlySaverVersion flag in JavaScript land.
- Do not touch/attempt to call any methods from the DOM applet node
  until this flag has been set.
- Demoted JavaLiveConnect in driver list order. Current browser security
  policies nearly render this driver useless. At best, can read own html
  file.
- Instead of picking currentDriver once at initialization, try all
  drivers until success each time. This is similar to how the current
  TiddlyWiki filesystem.js works.
- More reliable method of waiting for $.twFile.initialize() to complete
  successfully.
- availableDrivers() returns the list of drivers supported by the
  current driver.
- invokeDriver() is a utility method that tries calling a certain driver
  method on each driver until success.
- An `<object>` tag is inserted instead of an `<applet>` tag. `<applet>`
  caused IE to freeze. Anyways, the `<applet>` tag is deprecated.
