### PR TITLE
Fix tests: remove JSSpec mentions

### DIFF
--- a/test/README
+++ b/test/README
@@ -1,11 +1,6 @@
 This directory contains the test suite for the TiddlyWiki core.
 The framework being used is QUnit (http://docs.jquery.com/QUnit).
 
-N.B.:
-The use of JSSpec is gradually being phased out in favor of QUnit.
-Existing JSSpec-based tests are contained in the core/tests directory.
-cf. http://trac.tiddlywiki.org/ticket/963
-
 /html       required HTML components
 /js         actual test code for core modules
 /qunit      testing framework

--- a/test/js/Utilities.js
+++ b/test/js/Utilities.js
@@ -218,8 +218,7 @@ jQuery(document).ready(function() {
 			same(btn.i, attribs.i, message);
 	  }
 
-  // No tests in jsspec
-	// 'it should set the anchor accessKey attribute to the provided accessKey parameter': function() {}
+	// to do: add: 'it should set the anchor accessKey attribute to the provided accessKey parameter': function() {}
 
 	setUp('it should return the anchor element');
 		actual = btn.nodeName;


### PR DESCRIPTION
JSSpec tests were removed back in 2011(*), so these mentions are rather misleading. One mention (in [SavingRSS.js](https://github.com/TiddlyWiki/TiddlyWiki/blob/master/test/js/SavingRSS.js#L1)) is spared since it merely points that refactoring is needed (and it will be done indeed)

(*) see `git log --all -i --grep="JSSpec"` and in particular `git show 271ff99058dc8dbf859e3a14e2936c9a97031dfd` (or https://github.com/TiddlyWiki/TiddlyWiki/commit/271ff99058dc8dbf859e3a14e2936c9a97031dfd and https://github.com/TiddlyWiki/TiddlyWiki/tree/271ff99058dc8dbf859e3a14e2936c9a97031dfd/test)