### PR TITLE
Fix tests 3.7,3.8 and those in the range 34-58 (prevent crash of main())

### DIFF
--- a/test/qunit/qunit.js
+++ b/test/qunit/qunit.js
@@ -358,7 +358,9 @@ var config = {
 	config.filters = GETParams;
 	
 	// Figure out if we're running the tests from a server or not
-	QUnit.isLocal = !!(location.protocol === 'file:');
+	//QUnit.isLocal = !!(location.protocol === 'file:');
+	// removing isLocal since when set to window (extend(window, QUnit);), it overwrites TiddlyWiki's window.isLocal
+	// function which breaks startup (main()) and breaks a lot of tests
 })();
 
 // Expose the API as global variables, unless an 'exports'


### PR DESCRIPTION
The issue was discussed in the google group thread, starting from [this post](https://groups.google.com/d/msg/tiddlywikidev/xVZhedaXnS8/CsV0oWK-CQAJ). This seems to be the most appropriate fix; however, one has to be careful updating QUnit since that is likely to cause a regression (@Jermolene, @pmario, any suggestions regarding how to avoid such problem?).