### PR TITLE
fix box-sizing of editors

### DIFF
--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -144,7 +144,7 @@ table.listView th, table.listView td, table.listView tr {padding:0 3px 0 3px;}
 .viewer code {font-size:1.2em; line-height:1.4em;}
 
 .editor {font-size:1.1em;}
-.editor input, .editor textarea {display:block; width:100%; font:inherit;}
+.editor input, .editor textarea {display:block; width:100%; box-sizing: border-box; font:inherit;}
 .editorFooter {padding:0.25em 0; font-size:.9em;}
 .editorFooter .button {padding-top:0; padding-bottom:0;}
 


### PR DESCRIPTION
This fixes layout of edit macros in the edit mode (in Chrome and others where they are more than 100% in total width and inputs are narrower than textarea):

<table>
  <tr><td> before </td><td> after </td></tr>
  <tr><td><img width="140" alt="before" src="https://user-images.githubusercontent.com/1131924/37571151-d86a1322-2b09-11e8-98f7-4aaf88d5d95f.png"></td><td><img width="140" alt="after" src="https://user-images.githubusercontent.com/1131924/37571176-321b37a2-2b0a-11e8-972b-42eeafac3acd.png"></td></tr>
</table>