### PR TITLE
Fixing upgrading: URI to get the core from

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -133,7 +133,7 @@ config.macros = {
 	refreshDisplay: {},
 	importTiddlers: {},
 	upgrade: {
-		source: "http://tiddlywiki-releases.tiddlyspace.com/upgrade",
+		source: "http://classic.tiddlywiki.com/upgrade/",
 		backupExtension: "pre.core.upgrade"
 	},
 	sync: {},

--- a/js/Config.js
+++ b/js/Config.js
@@ -133,7 +133,7 @@ config.macros = {
 	refreshDisplay: {},
 	importTiddlers: {},
 	upgrade: {
-		source: "http://classic.tiddlywiki.com/upgrade/",
+		source: "https://classic.tiddlywiki.com/upgrade/",
 		backupExtension: "pre.core.upgrade"
 	},
 	sync: {},

--- a/js/Lingo.js
+++ b/js/Lingo.js
@@ -36,7 +36,8 @@ merge(config.optionsDesc,{
 	txtBackupFolder: "Name of folder to use for backups",
 	txtMaxEditRows: "Maximum number of rows in edit boxes",
 	txtTheme: "Name of the theme to use",
-	txtFileSystemCharSet: "Default character set for saving changes (Firefox/Mozilla only)"});
+	txtFileSystemCharSet: "Default character set for saving changes (Firefox/Mozilla only)"}),
+	txtUpgradeCoreURI: "Custom URI to download TiddlyWiki core from (when upgrading)";
 
 merge(config.messages,{
 	customConfigError: "Problems were encountered loading plugins. See PluginManager for details",

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -2,11 +2,15 @@
 //-- Upgrade macro
 //--
 
+config.macros.upgrade.getSourceURL = function() {
+	return config.macros.upgrade.source;
+};
+
 config.macros.upgrade.handler = function(place)
 {
 	var w = new Wizard();
 	w.createWizard(place,this.wizardTitle);
-	w.addStep(this.step1Title,this.step1Html.format([this.source,this.source]));
+	w.addStep(this.step1Title,this.step1Html.format([this.getSourceURL(),this.getSourceURL()]));
 	w.setButtons([{caption: this.upgradeLabel, tooltip: this.upgradePrompt, onClick: this.onClickUpgrade}]);
 };
 
@@ -37,15 +41,16 @@ config.macros.upgrade.onClickUpgrade = function(e)
 		return false;
 	}
 	w.setButtons([],me.statusLoadingCore);
+	var sourceURL = me.getSourceURL();
 	var options = {
 		type:"GET",
-		url:me.source,
+		url:sourceURL,
 		processData:false,
 		success:function(data,textStatus,jqXHR) {
-			me.onLoadCore(true,w,jqXHR.responseText,me.source,jqXHR);
+			me.onLoadCore(true,w,jqXHR.responseText,sourceURL,jqXHR);
 		},
 		error:function(jqXHR,textStatus,errorThrown) {
-			me.onLoadCore(false,w,null,me.source,jqXHR);
+			me.onLoadCore(false,w,null,sourceURL,jqXHR);
 		}
 	};
 	ajaxReq(options);

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -3,7 +3,7 @@
 //--
 
 config.macros.upgrade.getSourceURL = function() {
-	return config.macros.upgrade.source;
+	return config.options.txtUpgradeCoreURI || config.macros.upgrade.source;
 };
 
 config.macros.upgrade.handler = function(place)


### PR DESCRIPTION
Currently, the upgrade URL is set to unexisting http://tiddlywiki-releases.tiddlyspace.com/upgrade
This first set of upgrading fixes changes that to http://classic.tiddlywiki.com/upgrade/ and also introduces an option which can be used to set a custom path to load core from when upgrading (including a local path)

This allows to do upgrading from a local file and also is necessary to make upgrading from repo work again.

Feel free to suggest a better option description, if you can think of one.