### PR TITLE
Fix query and paramifier handling during upgrading

### DIFF
--- a/js/Saving.js
+++ b/js/Saving.js
@@ -95,11 +95,10 @@ function autoSaveChanges(onlyIfDirty,tiddlers)
 		saveChanges(onlyIfDirty,tiddlers);
 }
 
+// get the full HTML of the original file
 function loadOriginal(localPath)
 {
-	var content=loadFile(localPath);
-	if (!content) content=window.originalHTML||recreateOriginal();
-	return content;
+	return loadFile(localPath) || window.originalHTML || recreateOriginal();
 }
 
 //# reconstruct original HTML file content from current document memory
@@ -107,35 +106,35 @@ function recreateOriginal()
 {
 	// construct doctype
 	var content = "<!DOCTYPE ";
-	var t=document.doctype;
+	var t = document.doctype;
 	if (!t) 
-		content+="html"
+		content += "html"
 	else {
-		content+=t.name;
+		content += t.name;
 		if      (t.publicId)		content+=' PUBLIC "'+t.publicId+'"';
 		else if (t.systemId)		content+=' SYSTEM "'+t.systemId+'"';
 	}
-	content+=' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"';
-	content+='>\n';
+	content += ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"';
+	content += '>\n';
 
 	// append current document content
-	content+=document.documentElement.outerHTML;
+	content += document.documentElement.outerHTML;
 
 	//# clear 'savetest' marker
-	content=content.replace(/<div id="saveTest">savetest<\/div>/,'<div id="saveTest"></div>');
+	content = content.replace(/<div id="saveTest">savetest<\/div>/,'<div id="saveTest"></div>');
 	//# clear <applet> following </script>
-	content=content.replace(/script><applet [^\>]*><\/applet>/g,'script>');
+	content = content.replace(/script><applet [^\>]*><\/applet>/g,'script>');
 	//# newline before head tag
-	content=content.replace(/><head>/,'>\n<head>');
+	content = content.replace(/><head>/,'>\n<head>');
 	//# newlines before/after end of body/html tags
-	content=content.replace(/\n\n<\/body><\/html>$/,'</'+'body>\n</'+'html>\n'); // #170
+	content = content.replace(/\n\n<\/body><\/html>$/,'</'+'body>\n</'+'html>\n'); // #170
 	//# meta tag terminators
-	content=content.replace(/(<(meta) [^\>]*[^\/])>/g,'$1 />');
+	content = content.replace(/(<(meta) [^\>]*[^\/])>/g,'$1 />');
 	//# decode LT/GT entities in noscript
-	content=content.replace(/<noscript>[^\<]*<\/noscript>/,
-		function(m){return m.replace(/&lt;/g,'<').replace(/&gt;/g,'>');});
+	content = content.replace(/<noscript>[^\<]*<\/noscript>/,
+		function(m){ return m.replace(/&lt;/g,'<').replace(/&gt;/g,'>'); });
 	//# encode copyright symbols (UTF-8 to HTML entity)
-	content=content.replace(/<div id="copyright">[^\<]*<\/div>/,
+	content = content.replace(/<div id="copyright">[^\<]*<\/div>/,
 		function(m){return m.replace(/\xA9/g,'&copy;');});
 
 	return content;
@@ -173,9 +172,9 @@ function saveChanges(onlyIfDirty,tiddlers)
 		alert(msg.invalidFileError.format([localPath]));
 		return;
 	}
-	var co=config.options; //# abbreviation
-	config.saveByDownload=false;
-	config.saveByManualDownload=false;
+	var co = config.options; //# abbreviation
+	config.saveByDownload = false;
+	config.saveByManualDownload = false;
 	saveMain(localPath,original,posDiv);
 	if (!config.saveByDownload && !config.saveByManualDownload) {
 		if(co.chkSaveBackups)
@@ -302,4 +301,3 @@ function getBackupPath(localPath,title,extension)
 	backupPath += (new Date()).convertToYYYYMMDDHHMMSSMMM() + "." + (extension || "html");
 	return backupPath;
 }
-

--- a/js/Saving.js
+++ b/js/Saving.js
@@ -297,3 +297,4 @@ function getBackupPath(localPath,title,extension)
 	backupPath += (new Date()).convertToYYYYMMDDHHMMSSMMM() + "." + (extension || "html");
 	return backupPath;
 }
+

--- a/js/Saving.js
+++ b/js/Saving.js
@@ -218,13 +218,9 @@ function saveMain(localPath,original,posDiv)
 
 function saveBackup(localPath,original)
 {
-	//# Save the backup
 	var backupPath = getBackupPath(localPath);
-	var backup = copyFile(backupPath,localPath);
-	//# Browser does not support copy, so use save instead
-	if(!backup)
-		backup = saveFile(backupPath,original);
-	if(backup)
+	var backupSuccess = copyFile(backupPath,localPath) || saveFile(backupPath,original);
+	if(backupSuccess)
 		displayMessage(config.messages.backupSaved,"file://" + backupPath);
 	else
 		alert(config.messages.backupFailed);

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -75,9 +75,11 @@ config.macros.upgrade.onLoadCore = function(status,params,responseText,url,xhr)
 		return;
 	}
 	var onStartUpgrade = function(e) {
+		
 		w.setButtons([],me.statusSavingCore);
 		var localPath = getLocalPath(document.location.toString());
 		saveFile(localPath,responseText);
+		
 		w.setButtons([],me.statusReloadingCore);
 		var backupPath = w.getValue("backupPath");
 		var newLoc = document.location.toString() + "?time=" + new Date().convertToYYYYMMDDHHMM() + "#upgrade:[[" + encodeURI(backupPath) + "]]";
@@ -121,4 +123,3 @@ function upgradeFrom(path)
 	alert(config.messages.upgradeDone.format([formatVersion()]));
 	window.location = window.location.toString().substr(0,window.location.toString().lastIndexOf("?"));
 }
-

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -177,3 +177,4 @@ function upgradeFrom(path)
 	alert(config.messages.upgradeDone.format([formatVersion()]));
 	window.location = stripUpgradePartsFromURI(window.location.toString());
 }
+

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -2,7 +2,8 @@
 //-- Upgrade macro
 //--
 
-config.macros.upgrade.getSourceURL = function() {
+config.macros.upgrade.getSourceURL = function()
+{
 	return config.options.txtUpgradeCoreURI || config.macros.upgrade.source;
 };
 

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -27,20 +27,21 @@ config.macros.upgrade.onClickUpgrade = function(e)
 		alert(me.errorNotSaved);
 		return false;
 	}
+	
+	w.setButtons([],me.statusPreparingBackup);
 	var localPath = getLocalPath(document.location.toString());
 	var backupPath = getBackupPath(localPath,me.backupExtension);
-	w.setValue("backupPath",backupPath);
-	w.setButtons([],me.statusPreparingBackup);
 	var original = loadOriginal(localPath);
+	
 	w.setButtons([],me.statusSavingBackup);
-	var backup = copyFile(backupPath,localPath);
-	if(!backup)
-		backup = saveFile(backupPath,original);
-	if(!backup) {
+	var backupSuccess = copyFile(backupPath,localPath) || saveFile(backupPath,original);
+	if(!backupSuccess) {
 		w.setButtons([],me.errorSavingBackup);
 		alert(me.errorSavingBackup);
 		return false;
 	}
+	w.setValue("backupPath",backupPath);
+	
 	w.setButtons([],me.statusLoadingCore);
 	var sourceURL = me.getSourceURL();
 	var options = {


### PR DESCRIPTION
This update:

- fixes upgrade fail when trying to upgrade a TW open with a hash in URI
- treats query and hash carefully during upgrading (makes sure that those are the same after upgrading)
- brings several codestyle improvements and changes order of several commands in upgrading to give the code more clear semantics

probably should be merged by rebasing, although there's one or two more upgrading fixes on their way