### PR TITLE
Fix scope of encoding methods + minor things

### DIFF
--- a/js/FileAdaptor.js
+++ b/js/FileAdaptor.js
@@ -74,14 +74,14 @@ FileAdaptor.prototype.getTiddlerList = function(context,userParams,callback,filt
 		return context.complete(context,context.userParams);
 	}
 	var options = {
-		type:"GET",
-		url:context.host,
-		file:context.file, // for HTML5 FileReader
-		processData:false,
-		success:function(data,textStatus,jqXHR) {
+		type: "GET",
+		url: context.host,
+		file: context.file, // for HTML5 FileReader
+		processData: false,
+		success: function(data,textStatus,jqXHR) {
 			FileAdaptor.loadTiddlyWikiSuccess(context,jqXHR);
 		},
-		error:function(jqXHR,textStatus,errorThrown) {
+		error: function(jqXHR,textStatus,errorThrown) {
 			context.xhr = jqXHR;
 			FileAdaptor.loadTiddlyWikiError(context,jqXHR);
 		}

--- a/js/FileSystem.js
+++ b/js/FileSystem.js
@@ -186,7 +186,8 @@ function javaUrlToFilename(url)
  *
  */
 var LOG_TIDDLYSAVER = true;
-function logTiddlySaverException(msg, ex) {
+function logTiddlySaverException(msg, ex)
+{
 	var applet = document.applets['TiddlySaver'];
 	console.log(msg + ": " + ex);
 	if (LOG_TIDDLYSAVER && applet) {
@@ -197,7 +198,8 @@ function logTiddlySaverException(msg, ex) {
 	}
 }
 
-function javaDebugInformation () {
+function javaDebugInformation ()
+{
 	var applet = document.applets['TiddlySaver'];
 	var what = [
 		["Java Version", applet.getJavaVersion],
@@ -267,61 +269,65 @@ function javaLoadFile(filePath)
 
 function HTML5DownloadSaveFile(filePath,content)
 {
-	if(document.createElement("a").download !== undefined) {
-		config.saveByDownload=true;
-		var slashpos=filePath.lastIndexOf("/");
-		if (slashpos==-1) slashpos=filePath.lastIndexOf("\\"); 
-		var filename=filePath.substr(slashpos+1);
-		var uri = getDataURI(content);
-		var link = document.createElement("a");
-		link.setAttribute("target","_blank");
-		link.setAttribute("href",uri);
-		link.setAttribute("download",filename);
-		document.body.appendChild(link); link.click(); document.body.removeChild(link);
-		return true;
-	}
-	return null;
+	var link = document.createElement("a");
+	if(link.download === undefined)
+		return null;
+	
+	config.saveByDownload = true;
+	var slashpos = filePath.lastIndexOf("/");
+	if (slashpos==-1) slashpos = filePath.lastIndexOf("\\");
+	var filename = filePath.substr(slashpos+1);
+	var uri = getDataURI(content);
+	link.setAttribute("target","_blank");
+	link.setAttribute("href",uri);
+	link.setAttribute("download",filename);
+	document.body.appendChild(link); link.click(); document.body.removeChild(link);
+	return true;
 }
 
 // Returns null if it can't do it, false if there's an error, true if it saved OK
 function manualSaveFile(filePath,content)
 {
 	// FALLBACK for showing a link to data: URI
-	config.saveByManualDownload=true;
-	var slashpos=filePath.lastIndexOf("/");
-	if (slashpos==-1) slashpos=filePath.lastIndexOf("\\"); 
-	var filename=filePath.substr(slashpos+1);
+	config.saveByManualDownload = true;
+	var slashpos = filePath.lastIndexOf("/");
+	if (slashpos==-1) slashpos = filePath.lastIndexOf("\\");
+	var filename = filePath.substr(slashpos+1);
 	var uri = getDataURI(content);
 	displayMessage(config.messages.mainDownloadManual,uri);
 	return true;
 }
 
 // construct data URI (using base64 encoding to preserve multi-byte encodings)
-function getDataURI(data) {
+function getDataURI(data)
+{
 	if (config.browser.isIE)
 		return "data:text/html,"+encodeURIComponent(data);
 	else
 		return "data:text/html;base64,"+encodeBase64(data);
 }
 
-function encodeBase64(data) {
+function encodeBase64(data)
+{
 	if (!data) return "";
 	var keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 	var out = "";
-	var chr1,chr2,chr3="";
-	var enc1,enc2,enc3,enc4="";
-	for (var count=0,i=0; i<data.length; ) {
-		chr1=data.charCodeAt(i++);
-		chr2=data.charCodeAt(i++);
-		chr3=data.charCodeAt(i++);
-		enc1=chr1 >> 2;
-		enc2=((chr1 & 3) << 4) | (chr2 >> 4);
-		enc3=((chr2 & 15) << 2) | (chr3 >> 6);
-		enc4=chr3 & 63;
-		if (isNaN(chr2)) enc3=enc4=64;
-		else if (isNaN(chr3)) enc4=64;
-		out+=keyStr.charAt(enc1)+keyStr.charAt(enc2)+keyStr.charAt(enc3)+keyStr.charAt(enc4);
-		chr1=chr2=chr3=enc1=enc2=enc3=enc4="";
+	var chr1,chr2,chr3 = "";
+	var enc1,enc2,enc3,enc4 = "";
+	for (var count = 0, i = 0; i < data.length; )
+	{
+		chr1 = data.charCodeAt(i++);
+		chr2 = data.charCodeAt(i++);
+		chr3 = data.charCodeAt(i++);
+		enc1 = chr1 >> 2;
+		enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+		enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+		enc4 = chr3 & 63;
+		if (isNaN(chr2)) enc3 = enc4 = 64;
+		else if (isNaN(chr3)) enc4 = 64;
+		out += keyStr.charAt(enc1) + keyStr.charAt(enc2) + keyStr.charAt(enc3) + keyStr.charAt(enc4);
+		chr1 = chr2 = chr3 = enc1 = enc2 = enc3 = enc4 = "";
 	}
 	return out;
 }
+

--- a/js/FileSystem.js
+++ b/js/FileSystem.js
@@ -16,7 +16,6 @@ window.copyFile = window.copyFile || function(dest,source)
 	return config.browser.isIE ? ieCopyFile(dest,source) : false;
 }
 
-
 // Save a file in filesystem [Preemption]
 window.saveFile = window.saveFile || function(fileUrl,content)
 {
@@ -44,6 +43,7 @@ window.loadFile = window.loadFile || function(fileUrl)
 	return r;
 }
 
+
 function ieCreatePath(path)
 {
 	try {
@@ -68,7 +68,7 @@ function ieCreatePath(path)
 	}
 
 	//# Walk back down the path, creating folders
-	for(i=scan.length-1;i>=0;i--) {
+	for(i = scan.length-1; i >= 0; i--) {
 		if(!fso.FolderExists(scan[i])) {
 			fso.CreateFolder(scan[i]);
 		}
@@ -101,7 +101,7 @@ function ieLoadFile(filePath)
 		var content = file.ReadAll();
 		file.Close();
 	} catch(ex) {
-		//# alert("Exception while attempting to load\n\n" + ex.toString());
+		//# if(config.browser.isIE) alert("Exception while attempting to load\n\n" + ex.toString());
 		return null;
 	}
 	return content;
@@ -122,52 +122,52 @@ function ieCopyFile(dest,source)
 // Returns null if it can't do it, false if there's an error, true if it saved OK
 function mozillaSaveFile(filePath,content)
 {
-	if(window.Components) {
-		content = mozConvertUnicodeToUTF8(content);
-		try {
-			netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
-			var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-			file.initWithPath(filePath);
-			if(!file.exists())
-				file.create(0,0x01B4);// 0x01B4 = 0664
-			var out = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
-			out.init(file,0x22,0x04,null);
-			out.write(content,content.length);
-			out.flush();
-			out.close();
-			return true;
-		} catch(ex) {
-			//# alert("Exception while attempting to save\n\n" + ex);
-			return false;
-		}
+	if(!window.Components)
+		return null;
+	
+	content = mozConvertUnicodeToUTF8(content);
+	try {
+		netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
+		var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
+		file.initWithPath(filePath);
+		if(!file.exists())
+			file.create(0,0x01B4);// 0x01B4 = 0664
+		var out = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
+		out.init(file,0x22,0x04,null);
+		out.write(content,content.length);
+		out.flush();
+		out.close();
+		return true;
+	} catch(ex) {
+		//# alert("Exception while attempting to save\n\n" + ex);
+		return false;
 	}
-	return null;
 }
 
 // Returns null if it can't do it, false if there's an error, or a string of the content if successful
 function mozillaLoadFile(filePath)
 {
-	if(window.Components) {
-		try {
-			netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
-			var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-			file.initWithPath(filePath);
-			if(!file.exists())
-				return null;
-			var inputStream = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
-			inputStream.init(file,0x01,0x04,null);
-			var sInputStream = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
-			sInputStream.init(inputStream);
-			var contents = sInputStream.read(sInputStream.available());
-			sInputStream.close();
-			inputStream.close();
-			return mozConvertUTF8ToUnicode(contents);
-		} catch(ex) {
-			//# alert("Exception while attempting to load\n\n" + ex);
-			return false;
-		}
+	if(!window.Components)
+		return null;
+	
+	try {
+		netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
+		var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
+		file.initWithPath(filePath);
+		if(!file.exists())
+			return null;
+		var inputStream = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
+		inputStream.init(file,0x01,0x04,null);
+		var sInputStream = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+		sInputStream.init(inputStream);
+		var contents = sInputStream.read(sInputStream.available());
+		sInputStream.close();
+		inputStream.close();
+		return mozConvertUTF8ToUnicode(contents);
+	} catch(ex) {
+		//# alert("Exception while attempting to load\n\n" + ex);
+		return false;
 	}
-	return null;
 }
 
 function javaUrlToFilename(url)

--- a/js/FileSystem.js
+++ b/js/FileSystem.js
@@ -20,6 +20,7 @@ window.copyFile = window.copyFile || function(dest,source)
 // Save a file in filesystem [Preemption]
 window.saveFile = window.saveFile || function(fileUrl,content)
 {
+	content = convertUnicodeToFileFormat(content);
 	var r = mozillaSaveFile(fileUrl,content);
 	if(!r)
 		r = ieSaveFile(fileUrl,content);
@@ -82,11 +83,11 @@ function ieSaveFile(filePath,content)
 	try {
 		var fso = new ActiveXObject("Scripting.FileSystemObject");
 	} catch(ex) {
-		//# alert("Exception while attempting to save\n\n" + ex.toString());
+		//# if(config.browser.isIE) alert("Exception while attempting to save\n\n" + ex.toString());
 		return null;
 	}
 	var file = fso.OpenTextFile(filePath,2,-1,0);
-	file.Write(content);
+	file.Write(convertUnicodeToHtmlEntities(content));
 	file.Close();
 	return true;
 }
@@ -122,6 +123,7 @@ function ieCopyFile(dest,source)
 function mozillaSaveFile(filePath,content)
 {
 	if(window.Components) {
+		content = mozConvertUnicodeToUTF8(content);
 		try {
 			netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
 			var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
@@ -159,7 +161,7 @@ function mozillaLoadFile(filePath)
 			var contents = sInputStream.read(sInputStream.available());
 			sInputStream.close();
 			inputStream.close();
-			return contents;
+			return mozConvertUTF8ToUnicode(contents);
 		} catch(ex) {
 			//# alert("Exception while attempting to load\n\n" + ex);
 			return false;

--- a/js/FileSystemUtils.js
+++ b/js/FileSystemUtils.js
@@ -53,9 +53,11 @@ function mozConvertUTF8ToUnicode(u)
 
 //# convert unicode string to a format suitable for saving to file
 //# this should be UTF8, unless the browser does not support saving non-ASCII characters
+// currently, browser-specific convertion is only needed in browser-specific savers
+// so this converted doesn't do anything
 function convertUnicodeToFileFormat(s)
 {
-	return config.browser.isOpera || !window.netscape ? (config.browser.isIE ? convertUnicodeToHtmlEntities(s) : s) : mozConvertUnicodeToUTF8(s);
+	return s;
 }
 
 function convertUnicodeToHtmlEntities(s)
@@ -64,10 +66,10 @@ function convertUnicodeToHtmlEntities(s)
 	return s.replace(re,function($0) {return "&#" + $0.charCodeAt(0).toString() + ";";});
 }
 
+// deprecated helper for backward-compability with plugins and more
 function convertUnicodeToUTF8(s)
 {
-// return convertUnicodeToFileFormat to allow plugin migration
-	return convertUnicodeToFileFormat(s);
+	return s;
 }
 
 function manualConvertUnicodeToUTF8(s)

--- a/js/Http.js
+++ b/js/Http.js
@@ -14,21 +14,23 @@ function ajaxReq(args)
 //# perform local I/O and FAKE a minimal XHR response object
 function localAjax(args)
 {
-	var success=function(data)
-		{ args.success(data,"success",{ responseText:data }); }
-	var failure=function(who)
-		{ args.error({ message:who+": cannot read local file" },"error",0); }
+	var success = function(data) {
+		args.success(data,"success",{ responseText:data });
+	};
+	var failure = function(who) {
+		args.error({ message:who+": cannot read local file" },"error",0);
+	};
 
 	if (args.file) try { // HTML5 FileReader (Chrome, FF20+, Safari, etc.)
-		var reader=new FileReader();
-		reader.onload=function(e)  { success(e.target.result); }
-		reader.onerror=function(e) { failure("FileReader"); }
+		var reader = new FileReader();
+		reader.onload = function(e)  { success(e.target.result); }
+		reader.onerror = function(e) { failure("FileReader"); }
 		reader.readAsText(args.file);
 		return true;
 	} catch (ex) { ; }
 
 	try { // local file I/O (IE, FF with TiddlyFox, Chrome/Safari with TiddlySaver, etc.)
-		var data=loadFile(getLocalPath(args.url));
+		var data = loadFile(getLocalPath(args.url));
 		if (data) success(data);
 		else failure("loadFile");
 		return true;
@@ -69,11 +71,11 @@ function httpReq(type,url,callback,params,headers,data,contentType,username,pass
 	};
 
 	var options = {
-		type:type,
-		url:url,
-		processData:false,
-		data:data,
-		cache:!!allowCache,
+		type: type,
+		url: url,
+		processData: false,
+		data: data,
+		cache: !!allowCache,
 		beforeSend: function(xhr) {
 			var i;
 			for(i in headers)

--- a/js/Import.js
+++ b/js/Import.js
@@ -239,8 +239,8 @@ config.macros.importTiddlers.onOpenWorkspace = function(context,wizard)
 	if(context.status !== true)
 		displayMessage("Error in importTiddlers.onOpenWorkspace: " + context.statusText);
 	var adaptor = wizard.getValue("adaptor");
-	var browse=wizard.getElement("txtBrowse");
-	if (browse.files) context.file=browse.files[0]; // for HTML5 FileReader
+	var browse = wizard.getElement("txtBrowse");
+	if (browse.files) context.file = browse.files[0]; // for HTML5 FileReader
 	adaptor.getTiddlerList(context,wizard,me.onGetTiddlerList,wizard.getValue("feedTiddlerFilter"));
 	wizard.setButtons([{caption: me.cancelLabel, tooltip: me.cancelPrompt, onClick: me.onCancel}],me.statusGetTiddlerList);
 };

--- a/js/Saving.js
+++ b/js/Saving.js
@@ -193,12 +193,12 @@ function saveMain(localPath,original,posDiv)
 {
 	var save;
 	try {
-		//# Save new file
 		var revised = updateOriginal(original,posDiv,localPath);
 		save = saveFile(localPath,revised);
 	} catch (ex) {
 		showException(ex);
 	}
+	//# Report status to user
 	if(save) {
 		if (!config.saveByManualDownload) {
 			if (config.saveByDownload) { //# set by HTML5DownloadSaveFile()

--- a/js/Saving.js
+++ b/js/Saving.js
@@ -49,7 +49,7 @@ function updateMarkupBlock(s,blockName,tiddlerName)
 	return s.replaceChunk(
 			"<!--%0-START-->".format([blockName]),
 			"<!--%0-END-->".format([blockName]),
-			"\n" + convertUnicodeToFileFormat(store.getRecursiveTiddlerText(tiddlerName,"")) + "\n");
+			"\n" + store.getRecursiveTiddlerText(tiddlerName,"") + "\n");
 }
 
 function updateOriginal(original,posDiv,localPath)
@@ -61,9 +61,9 @@ function updateOriginal(original,posDiv,localPath)
 		return null;
 	}
 	var revised = original.substr(0,posDiv[0] + startSaveArea.length) + "\n" +
-				convertUnicodeToFileFormat(store.allTiddlersAsHtml()) + "\n" +
+				store.allTiddlersAsHtml() + "\n" +
 				original.substr(posDiv[1]);
-	var newSiteTitle = convertUnicodeToFileFormat(getPageTitle()).htmlEncode();
+	var newSiteTitle = getPageTitle().htmlEncode();
 	revised = revised.replaceChunk("<title"+">","</title"+">"," " + newSiteTitle + " ");
 	revised = updateLanguageAttribute(revised);
 	revised = updateMarkupBlock(revised,"PRE-HEAD","MarkupPreHead");

--- a/js/SavingRSS.js
+++ b/js/SavingRSS.js
@@ -5,7 +5,7 @@
 function saveRss(localPath)
 {
 	var rssPath = localPath.substr(0,localPath.lastIndexOf(".")) + ".xml";
-	if(saveFile(rssPath,convertUnicodeToFileFormat(generateRss())))
+	if(saveFile(rssPath,generateRss()))
 		displayMessage(config.messages.rssSaved,"file://" + rssPath);
 	else
 		alert(config.messages.rssFailed);

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -122,7 +122,7 @@ function changeUri(uri, modify)
 	var newScheme = parts.scheme === undefined ? '' : (parts.scheme + '//'),
 	    newHost   = parts.host || '',
 	    newPath   = parts.path || '',
-	    newQuery  = parts.query  === undefined ? '' : ('?' + parts.query),
+	    newQuery  = parts.query ? ('?' + parts.query) : '',
 	    newHash   = parts.hash   === undefined ? '' : ('#' + parts.hash);
 	return newScheme + newHost + newPath + newQuery + newHash;
 }
@@ -156,7 +156,7 @@ function stripUpgradePartsFromURI(uri)
 				hashParts = hashParts.slice(0,i);
 		
 		uriParts.query = queryParts.join('&');
-		uriParts.hash = hashParts.join('%20');
+		uriParts.hash = hashParts.join('%20') || undefined;
 	})
 }
 

--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -164,8 +164,6 @@ function upgradeFrom(path)
 {
 	var importStore = new TiddlyWiki();
 	var tw = loadFile(path);
-	if(window.netscape !== undefined)
-		tw = convertUTF8ToUnicode(tw);
 	importStore.importTiddlyWiki(tw);
 	importStore.forEachTiddler(function(title,tiddler) {
 		if(!store.getTiddler(title)) {


### PR DESCRIPTION
Most of the analysis of the main commit can be found in [this thread](https://groups.google.com/forum/#!topic/tiddlywikiclassic/RW_vsuUHnYI) and [this post](https://groups.google.com/d/msg/tiddlywikiclassic/RW_vsuUHnYI/FjLie5MGCwAJ) in particular.

An outline:
* `convertUTF8ToUnicode` is moved from `upgradeFrom` to `mozillaLoadFile` and substited with a narrower `mozConvertUTF8ToUnicode` so that the scope of conversion is limited to only the old `mozillaLoadFile` method used in FF 14 and earlier. This, along with changing saving methods is primarily to fix #121 
* `convertUnicodeToFileFormat` is moved from `updateMarkupBlock`, `updateOriginal`, `saveRss` and `convertUnicodeToUTF8` to `saveFile` (it affects only non-ASCII characters) and so is applied universaly
* but its implementation is further moved:
  * `mozConvertUnicodeToUTF8` to `mozillaSaveFile` (somewhat surprisingly, this doesn't affect saving via TiddlyFox, tested at least in FF 4, 10, 14, 15 & 54), so this conversion is really needed for saving in old FF without TF;
  * `convertUnicodeToHtmlEntities` is moved from `convertUnicodeToFileFormat` to `ieSaveFile` and the `.isIE` check is stripped
    * this fixes IE 11 not saving TW (to do in the future: fix calculation of `config.browser.isIE` – doesn't recognize IE 11 now; presumably should be calced using feature detection)
    * this also introduces potential problems for saving non-html files in IE: if those contain non-ASCII symbols, they will be substituted with html entities – however, without this fix they get corrupted, so this problem should be addressed separately (if there's at least one TW user who needs this)
  * so basically `convertUnicodeToFileFormat` does nothing and is left for the case of some more encoding adjustments (for old browsers?)
* in `mozillaSaveFile` and `mozillaLoadFile`, the check is inverted for better readability of the code; in `HTML5DownloadSaveFile` a similar simplification is done
* codestyle fixes consist of adding missing spaces (mostly around `=`) and changing

      function blabla() {
          ...
      }

    to

      function blabla()
      {
          ...
      }

* changes in `changeUri` and `stripUpgradePartsFromURI` remove empty ? and # in URL after upgrading if no query and/or hash was there in the URL before. Hash and query are treated differently because empty hash is used sometimes while empty query makes no sense
* I know, these should be 3 different PRs, but hey, let's move on