### PR TITLE
Improving styles

### DIFF
--- a/js/Backstage.js
+++ b/js/Backstage.js
@@ -36,7 +36,7 @@ var backstage = {
 		this.panelBody = createTiddlyElement(this.panel,"div",null,"backstagePanelBody");
 		this.cloak.onmousedown = function(e) {backstage.switchTab(null);};
 		createTiddlyText(this.toolbar,cmb.prompt);
-		for(t=0; t<config.backstageTasks.length; t++) {
+		for(t = 0; t < config.backstageTasks.length; t++) {
 			var taskName = config.backstageTasks[t];
 			var task = config.tasks[taskName];
 			var handler = task.action ? this.onClickCommand : this.onClickTab;
@@ -44,7 +44,7 @@ var backstage = {
 			var btn = createTiddlyButton(this.toolbar,text,task.tooltip,handler,"backstageTab");
 			jQuery(btn).addClass(task.action ? "backstageAction" : "backstageTask");
 			btn.setAttribute("task", taskName);
-			}
+		}
 		this.content = document.getElementById("contentWrapper");
 		if(config.options.chkBackstage)
 			this.show();
@@ -168,7 +168,7 @@ var backstage = {
 				{style: "top", start: 0, end: -(backstage.panel.offsetHeight), template: "%0px"},
 				{style: "display", atEnd: "none"}
 			];
-			var c = function(element,properties) {backstage.cloak.style.display = "none";};
+			var c = function(element,properties) { backstage.cloak.style.display = "none"; };
 			anim.startAnimating(new Morpher(backstage.panel,config.animDuration,p,c));
 		} else {
 			jQuery([backstage.panel,backstage.cloak]).hide();
@@ -182,6 +182,8 @@ config.macros.backstage.handler = function(place,macroName,params)
 {
 	var backstageTask = config.tasks[params[0]];
 	if(backstageTask)
-		createTiddlyButton(place,backstageTask.text,backstageTask.tooltip,function(e) {backstage.switchTab(params[0]); return false;});
+		createTiddlyButton(place,backstageTask.text,backstageTask.tooltip,function(e) {
+			backstage.switchTab(params[0]); return false;
+		});
 };
 

--- a/js/Backstage.js
+++ b/js/Backstage.js
@@ -24,19 +24,20 @@ var backstage = {
 		this.toolbar = jQuery("#backstageToolbar").empty()[0];
 		this.button = jQuery("#backstageButton").empty()[0];
 		this.button.style.display = "block";
-		var t = cmb.open.text + " " + glyph("bentArrowLeft");
-		this.showButton = createTiddlyButton(this.button,t,cmb.open.tooltip,
-						function(e) {backstage.show(); return false;},null,"backstageShow");
-		t = glyph("bentArrowRight") + " " + cmb.close.text;
-		this.hideButton = createTiddlyButton(this.button,t,cmb.close.tooltip,
-						function(e) {backstage.hide(); return false;},null,"backstageHide");
+		var text = cmb.open.text + " " + glyph("bentArrowLeft");
+		this.showButton = createTiddlyButton(this.button,text,cmb.open.tooltip,
+			function(e) { backstage.show(); return false; },null,"backstageShow");
+		text = glyph("bentArrowRight") + " " + cmb.close.text;
+		this.hideButton = createTiddlyButton(this.button,text,cmb.close.tooltip,
+			function(e) { backstage.hide(); return false; },null,"backstageHide");
 		this.cloak = document.getElementById("backstageCloak");
 		this.panel = document.getElementById("backstagePanel");
 		this.panelFooter = createTiddlyElement(this.panel,"div",null,"backstagePanelFooter");
 		this.panelBody = createTiddlyElement(this.panel,"div",null,"backstagePanelBody");
-		this.cloak.onmousedown = function(e) {backstage.switchTab(null);};
+		this.cloak.onmousedown = function(e) { backstage.switchTab(null); };
 		createTiddlyText(this.toolbar,cmb.prompt);
-		for(t = 0; t < config.backstageTasks.length; t++) {
+		for(var t = 0; t < config.backstageTasks.length; t++)
+		{
 			var taskName = config.backstageTasks[t];
 			var task = config.tasks[taskName];
 			var handler = task.action ? this.onClickCommand : this.onClickTab;

--- a/js/Lingo.js
+++ b/js/Lingo.js
@@ -62,7 +62,7 @@ merge(config.messages,{
 	rssFailed: "Failed to save RSS feed file",
 	emptySaved: "Empty template saved",
 	emptyFailed: "Failed to save empty template file",
-	mainSaved: "Main TiddlyWiki file saved",
+	mainSaved: "TiddlyWiki saved",
 	mainDownload: "Downloading/saving main TiddlyWiki file",
 	mainDownloadManual: "RIGHT CLICK HERE to download/save main TiddlyWiki file",
 	mainFailed: "Failed to save main TiddlyWiki file. Your changes have not been saved",

--- a/js/Lingo.js
+++ b/js/Lingo.js
@@ -5,7 +5,8 @@
 // Strings in "double quotes" should be translated; strings in 'single quotes' should be left alone
 
 merge(config.options,{
-	txtUserName: "YourName"});
+	txtUserName: "YourName"
+});
 
 merge(config.tasks,{
 	save: {text: "save", tooltip: "Save your changes to this TiddlyWiki"},
@@ -37,7 +38,8 @@ merge(config.optionsDesc,{
 	txtMaxEditRows: "Maximum number of rows in edit boxes",
 	txtTheme: "Name of the theme to use",
 	txtFileSystemCharSet: "Default character set for saving changes (Firefox/Mozilla only)",
-	txtUpgradeCoreURI: "Custom URI to download TiddlyWiki core from (when upgrading)"});
+	txtUpgradeCoreURI: "Custom URI to download TiddlyWiki core from (when upgrading)"
+});
 
 merge(config.messages,{
 	customConfigError: "Problems were encountered loading plugins. See PluginManager for details",
@@ -81,11 +83,13 @@ merge(config.messages,{
 	fieldCannotBeChanged: "Field '%0' cannot be changed",
 	loadingMissingTiddler: "Attempting to retrieve the tiddler '%0' from the '%1' server at:\n\n'%2' in the workspace '%3'",
 	upgradeDone: "The upgrade to version %0 is now complete\n\nClick 'OK' to reload the newly upgraded TiddlyWiki",
-	invalidCookie: "Invalid cookie '%0'"});
+	invalidCookie: "Invalid cookie '%0'"
+});
 
 merge(config.messages.messageClose,{
 	text: "close",
-	tooltip: "close this message area"});
+	tooltip: "close this message area"
+});
 
 config.messages.backstage = {
 	open: {text: "backstage", tooltip: "Open the backstage area to perform authoring and editing tasks"},
@@ -113,8 +117,7 @@ config.messages.dates.daySuffixes = ["st","nd","rd","th","th","th","th","th","th
 config.messages.dates.am = "am";
 config.messages.dates.pm = "pm";
 
-merge(config.messages.tiddlerPopup,{
-	});
+merge(config.messages.tiddlerPopup,{});
 
 merge(config.views.wikified.tag,{
 	labelNoTags: "no tags",
@@ -123,33 +126,38 @@ merge(config.views.wikified.tag,{
 	tooltip: "Show tiddlers tagged with '%0'",
 	openAllText: "Open all",
 	openAllTooltip: "Open all of these tiddlers",
-	popupNone: "No other tiddlers tagged with '%0'"});
+	popupNone: "No other tiddlers tagged with '%0'"
+});
 
 merge(config.views.wikified,{
 	defaultText: "The tiddler '%0' doesn't yet exist. Double-click to create it",
 	defaultModifier: "(missing)",
 	shadowModifier: "(built-in shadow tiddler)",
 	dateFormat: "DD MMM YYYY",
-	createdPrompt: "created"});
+	createdPrompt: "created"
+});
 
 merge(config.views.editor,{
 	tagPrompt: "Type tags separated with spaces, [[use double square brackets]] if necessary, or add existing",
-	defaultText: "Type the text for '%0'"});
+	defaultText: "Type the text for '%0'"
+});
 
 merge(config.views.editor.tagChooser,{
 	text: "tags",
 	tooltip: "Choose existing tags to add to this tiddler",
 	popupNone: "There are no tags defined",
-	tagTooltip: "Add the tag '%0'"});
+	tagTooltip: "Add the tag '%0'"
+});
 
 merge(config.messages,{
 	sizeTemplates:
-		[
+	[
 		{unit: 1024*1024*1024, template: "%0\u00a0GB"},
 		{unit: 1024*1024, template: "%0\u00a0MB"},
 		{unit: 1024, template: "%0\u00a0KB"},
 		{unit: 1, template: "%0\u00a0B"}
-		]});
+	]
+});
 
 merge(config.macros.search,{
 	label: "search",
@@ -157,19 +165,23 @@ merge(config.macros.search,{
 	placeholder: "",
 	accessKey: "F",
 	successMsg: "%0 tiddlers found matching %1",
-	failureMsg: "No tiddlers found matching %0"});
+	failureMsg: "No tiddlers found matching %0"
+});
 
 merge(config.macros.tagging,{
 	label: "tagging: ",
 	labelNotTag: "not tagging",
-	tooltip: "List of tiddlers tagged with '%0'"});
+	tooltip: "List of tiddlers tagged with '%0'"
+});
 
 merge(config.macros.timeline,{
-	dateFormat: "DD MMM YYYY"});
+	dateFormat: "DD MMM YYYY"
+});
 
 merge(config.macros.allTags,{
 	tooltip: "Show tiddlers tagged with '%0'",
-	noTags: "There are no tagged tiddlers"});
+	noTags: "There are no tagged tiddlers"
+});
 
 config.macros.list.all.prompt = "All tiddlers in alphabetical order";
 config.macros.list.missing.prompt = "Tiddlers that have links to them but are not defined";
@@ -179,27 +191,32 @@ config.macros.list.touched.prompt = "Tiddlers that have been modified locally";
 
 merge(config.macros.closeAll,{
 	label: "close all",
-	prompt: "Close all displayed tiddlers (except any that are being edited)"});
+	prompt: "Close all displayed tiddlers (except any that are being edited)"
+});
 
 merge(config.macros.permaview,{
 	label: "permaview",
-	prompt: "Link to an URL that retrieves all the currently displayed tiddlers"});
+	prompt: "Link to an URL that retrieves all the currently displayed tiddlers"
+});
 
 merge(config.macros.saveChanges,{
 	label: "save changes",
 	prompt: "Save all tiddlers to create a new TiddlyWiki",
-	accessKey: "S"});
+	accessKey: "S"
+});
 
 merge(config.macros.newTiddler,{
 	label: "new tiddler",
 	prompt: "Create a new tiddler",
 	title: "New Tiddler",
-	accessKey: "N"});
+	accessKey: "N"
+});
 
 merge(config.macros.newJournal,{
 	label: "new journal",
 	prompt: "Create a new tiddler from the current date and time",
-	accessKey: "J"});
+	accessKey: "J"
+});
 
 merge(config.macros.options,{
 	wizardTitle: "Tweak advanced options",
@@ -211,11 +228,12 @@ merge(config.macros.options,{
 			{name: 'Option', field: 'option', title: "Option", type: 'String'},
 			{name: 'Description', field: 'description', title: "Description", type: 'WikiText'},
 			{name: 'Name', field: 'name', title: "Name", type: 'String'}
-			],
+		],
 		rowClasses: [
 			{className: 'lowlight', field: 'lowlight'}
-			]}
-	});
+		]
+	}
+});
 
 merge(config.macros.plugins,{
 	wizardTitle: "Manage plugins",
@@ -241,11 +259,12 @@ merge(config.macros.plugins,{
 			{name: 'Startup Time', field: 'startupTime', title: "Startup Time", type: 'String'},
 			{name: 'Error', field: 'error', title: "Status", type: 'Boolean', trueText: "Error", falseText: "OK"},
 			{name: 'Log', field: 'log', title: "Log", type: 'StringList'}
-			],
+		],
 		rowClasses: [
 			{className: 'error', field: 'error'},
 			{className: 'warning', field: 'warning'}
-			]},
+		]
+	},
 	listViewTemplateReadOnly: {
 		columns: [
 			{name: 'Tiddler', field: 'tiddler', title: "Tiddler", type: 'Tiddler'},
@@ -256,12 +275,13 @@ merge(config.macros.plugins,{
 			{name: 'Startup Time', field: 'startupTime', title: "Startup Time", type: 'String'},
 			{name: 'Error', field: 'error', title: "Status", type: 'Boolean', trueText: "Error", falseText: "OK"},
 			{name: 'Log', field: 'log', title: "Log", type: 'StringList'}
-			],
+		],
 		rowClasses: [
 			{className: 'error', field: 'error'},
 			{className: 'warning', field: 'warning'}
-			]}
-	});
+		]
+	}
+});
 
 merge(config.macros.toolbar,{
 	moreLabel: "more",
@@ -269,12 +289,12 @@ merge(config.macros.toolbar,{
 	lessLabel: "less",
 	lessPrompt: "Hide additional commands",
 	separator: "|"
-	});
+});
 
 merge(config.macros.refreshDisplay,{
 	label: "refresh",
 	prompt: "Redraw the entire TiddlyWiki display"
-	});
+});
 
 merge(config.macros.importTiddlers,{
 	readOnlyWarning: "You cannot import into a read-only TiddlyWiki file. Try opening it from a file:// URL",
@@ -317,10 +337,10 @@ merge(config.macros.importTiddlers,{
 			{name: 'Tiddler', field: 'tiddler', title: "Tiddler", type: 'Tiddler'},
 			{name: 'Size', field: 'size', tiddlerLink: 'size', title: "Size", type: 'Size'},
 			{name: 'Tags', field: 'tags', title: "Tags", type: 'Tags'}
-			],
-		rowClasses: [
-			]}
-	});
+		],
+		rowClasses: []
+	}
+});
 
 merge(config.macros.upgrade,{
 	wizardTitle: "Upgrade TiddlyWiki core code",
@@ -348,53 +368,61 @@ merge(config.macros.upgrade,{
 	cancelPrompt: "Cancel the upgrade process",
 	step3Title: "Upgrade cancelled",
 	step3Html: "You have cancelled the upgrade process"
-	});
+});
 
-merge(config.macros.annotations,{
-	});
+merge(config.macros.annotations,{});
 
 merge(config.commands.closeTiddler,{
 	text: "close",
-	tooltip: "Close this tiddler"});
+	tooltip: "Close this tiddler"
+});
 
 merge(config.commands.closeOthers,{
 	text: "close others",
-	tooltip: "Close all other tiddlers"});
+	tooltip: "Close all other tiddlers"
+});
 
 merge(config.commands.editTiddler,{
 	text: "edit",
 	tooltip: "Edit this tiddler",
 	readOnlyText: "view",
-	readOnlyTooltip: "View the source of this tiddler"});
+	readOnlyTooltip: "View the source of this tiddler"
+});
 
 merge(config.commands.saveTiddler,{
 	text: "done",
-	tooltip: "Save changes to this tiddler"});
+	tooltip: "Save changes to this tiddler"
+});
 
 merge(config.commands.cancelTiddler,{
 	text: "cancel",
 	tooltip: "Undo changes to this tiddler",
 	warning: "Are you sure you want to abandon your changes to '%0'?",
 	readOnlyText: "done",
-	readOnlyTooltip: "View this tiddler normally"});
+	readOnlyTooltip: "View this tiddler normally"
+});
 
 merge(config.commands.deleteTiddler,{
 	text: "delete",
 	tooltip: "Delete this tiddler",
-	warning: "Are you sure you want to delete '%0'?"});
+	warning: "Are you sure you want to delete '%0'?"
+});
 
 merge(config.commands.permalink,{
 	text: "permalink",
-	tooltip: "Permalink for this tiddler"});
+	tooltip: "Permalink for this tiddler"
+});
 
 merge(config.commands.references,{
 	text: "references",
 	tooltip: "Show tiddlers that link to this one",
-	popupNone: "No references"});
+	popupNone: "No references"
+});
 
 merge(config.commands.jump,{
 	text: "jump",
-	tooltip: "Jump to another open tiddler"});
+	tooltip: "Jump to another open tiddler"
+});
 
 merge(config.commands.fields,{
 	text: "fields",
@@ -404,11 +432,11 @@ merge(config.commands.fields,{
 		columns: [
 			{name: 'Field', field: 'field', title: "Field", type: 'String'},
 			{name: 'Value', field: 'value', title: "Value", type: 'String'}
-			],
-		rowClasses: [
-			],
-		buttons: [
-			]}});
+		],
+		rowClasses: [],
+		buttons: []
+	}
+});
 
 merge(config.shadowTiddlers,{
 	DefaultTiddlers: "[[GettingStarted]]",
@@ -419,7 +447,7 @@ merge(config.shadowTiddlers,{
 	SideBarOptions: '<<search>><<closeAll>><<permaview>><<newTiddler>><<newJournal "DD MMM YYYY" "journal">><<saveChanges>><<slider chkSliderOptionsPanel OptionsPanel "options \u00bb" "Change TiddlyWiki advanced options">>',
 	SideBarTabs: '<<tabs txtMainTab "Timeline" "Timeline" TabTimeline "All" "All tiddlers" TabAll "Tags" "All tags" TabTags "More" "More lists" TabMore>>',
 	TabMore: '<<tabs txtMoreTab "Missing" "Missing tiddlers" TabMoreMissing "Orphans" "Orphaned tiddlers" TabMoreOrphans "Shadowed" "Shadowed tiddlers" TabMoreShadowed>>'
-	});
+});
 
 merge(config.annotations,{
 	AdvancedOptions: "This shadow tiddler provides access to several advanced options",
@@ -456,4 +484,4 @@ merge(config.annotations,{
 	TabTimeline: "This shadow tiddler contains the contents of the 'Timeline' tab in the right-hand sidebar",
 	ToolbarCommands: "This shadow tiddler determines which commands are shown in tiddler toolbars",
 	ViewTemplate: "The HTML template in this shadow tiddler determines how tiddlers look"
-	});
+});

--- a/js/Messages.js
+++ b/js/Messages.js
@@ -8,12 +8,13 @@ function getMessageDiv()
 	if(!msgArea)
 		return null;
 	if(!msgArea.hasChildNodes())
-		createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageToolbar"),
+		createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar"),
 			config.messages.messageClose.text,
 			config.messages.messageClose.tooltip,
-			clearMessage);
+			clearMessage,
+			"button messageToolbar__button");
 	msgArea.style.display = "block";
-	return createTiddlyElement(msgArea,"div");
+	return createTiddlyElement(msgArea,"div",null,"messageArea__text");
 }
 
 function displayMessage(text,linkText)

--- a/js/Messages.js
+++ b/js/Messages.js
@@ -7,12 +7,19 @@ function getMessageDiv()
 	var msgArea = document.getElementById("messageArea");
 	if(!msgArea)
 		return null;
-	if(!msgArea.hasChildNodes())
-		createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar"),
+	if(!msgArea.hasChildNodes()) {
+		var btn = createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar"),
 			config.messages.messageClose.text,
 			config.messages.messageClose.tooltip,
 			clearMessage,
 			"button messageToolbar__button");
+		if(!config.options.chkDontUseSvgIcons) {
+			btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" class="messageToolbar__icon">'+
+			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(-45 5 5)"/>'+
+			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(+45 5 5)"/>'+
+			'</svg>';
+		}
+	}
 	msgArea.style.display = "block";
 	return createTiddlyElement(msgArea,"div",null,"messageArea__text");
 }

--- a/js/Messages.js
+++ b/js/Messages.js
@@ -9,15 +9,17 @@ function getMessageDiv()
 		return null;
 	if(!msgArea.hasChildNodes()) {
 		var btn = createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar"),
-			config.messages.messageClose.text,
+			'',
 			config.messages.messageClose.tooltip,
 			clearMessage,
 			"button messageToolbar__button");
-		if(!config.options.chkDontUseSvgIcons) {
-			btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" class="messageToolbar__icon">'+
-			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(-45 5 5)"/>'+
-			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(+45 5 5)"/>'+
-			'</svg>';
+		btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" class="messageToolbar__icon">'+
+		'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(-45 5 5)"/>'+
+		'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(+45 5 5)"/>'+
+		'</svg>';
+		if(window.HTMLUnknownElement && btn.firstChild instanceof window.HTMLUnknownElement) {
+			btn.innerHTML = config.messages.messageClose.text;
+		} else {
 			btn.classList.add('messageToolbar__button_withIcon');
 		}
 	}

--- a/js/Messages.js
+++ b/js/Messages.js
@@ -8,15 +8,15 @@ function getMessageDiv()
 	if(!msgArea)
 		return null;
 	if(!msgArea.hasChildNodes()) {
-		var btn = createTiddlyButton(createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar"),
-			'',
-			config.messages.messageClose.tooltip,
-			clearMessage,
+		var toolbar = createTiddlyElement(msgArea,"div",null,"messageArea__toolbar messageToolbar");
+		var btn = createTiddlyButton(toolbar, '', config.messages.messageClose.tooltip, clearMessage,
 			"button messageToolbar__button");
+
 		btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" class="messageToolbar__icon">'+
 		'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(-45 5 5)"/>'+
 		'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(+45 5 5)"/>'+
 		'</svg>';
+		// inline SVG is unsupported in old FireFox
 		if(window.HTMLUnknownElement && btn.firstChild instanceof window.HTMLUnknownElement) {
 			btn.innerHTML = config.messages.messageClose.text;
 		} else {
@@ -27,19 +27,17 @@ function getMessageDiv()
 	return createTiddlyElement(msgArea,"div",null,"messageArea__text");
 }
 
-function displayMessage(text,linkText)
+function displayMessage(text, link)
 {
 	var e = getMessageDiv();
 	if(!e) {
 		alert(text);
 		return;
 	}
-	if(linkText) {
-		var link = createTiddlyElement(e,"a",null,null,text);
-		link.href = linkText;
-		link.target = "_blank";
-	} else {
+	if(!link) {
 		e.appendChild(document.createTextNode(text));
+	} else {
+		createTiddlyElement(e,"a",null,null,text,{ href: link, target: "_blank" });
 	}
 }
 

--- a/js/Messages.js
+++ b/js/Messages.js
@@ -18,6 +18,7 @@ function getMessageDiv()
 			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(-45 5 5)"/>'+
 			'	<rect width="1" height="13.1" x="4.5" y="-1.6" transform="rotate(+45 5 5)"/>'+
 			'</svg>';
+			btn.classList.add('messageToolbar__button_withIcon');
 		}
 	}
 	msgArea.style.display = "block";

--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -27,8 +27,8 @@ Wizard.prototype.getValue = function(name)
 
 Wizard.prototype.createWizard = function(place,title)
 {
-	this.formElem = createTiddlyElement(place,"form",null,"wizard");
-	createTiddlyElement(this.formElem,"h1",null,null,title);
+	this.formElem = createTiddlyElement(place,'form',null,'wizard');
+	createTiddlyElement(this.formElem,'h1',null,'wizard__title',title);
 	this.bodyElem = createTiddlyElement(this.formElem,"div",null,"wizardBody");
 	this.footElem = createTiddlyElement(this.formElem,"div",null,"wizardFooter");
 	return this.formElem;
@@ -55,8 +55,8 @@ Wizard.prototype.setButtons = function(buttonInfo,status)
 Wizard.prototype.addStep = function(stepTitle,html)
 {
 	jQuery(this.bodyElem).empty();
-	var w = createTiddlyElement(this.bodyElem,"div");
-	createTiddlyElement(w,"h2",null,null,stepTitle);
+	var w = createTiddlyElement(this.bodyElem,'div');
+	createTiddlyElement(w,'h2',null,'wizard__subtitle',stepTitle);
 	var step = createTiddlyElement(w,"div",null,"wizardStep");
 	step.innerHTML = html;
 	applyHtmlMacros(step,tiddler);

--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -42,11 +42,10 @@ Wizard.prototype.clear = function()
 Wizard.prototype.setButtons = function(buttonInfo,status)
 {
 	jQuery(this.footElem).empty();
-	var t;
-	for(t=0; t<buttonInfo.length; t++) {
+	for(var t = 0; t < buttonInfo.length; t++) {
 		createTiddlyButton(this.footElem,buttonInfo[t].caption,buttonInfo[t].tooltip,buttonInfo[t].onClick);
 		insertSpacer(this.footElem);
-		}
+	}
 	if(typeof status == "string") {
 		createTiddlyElement(this.footElem,"span",null,"status",status);
 	}

--- a/shadows/PageTemplate.tid
+++ b/shadows/PageTemplate.tid
@@ -17,7 +17,7 @@ title: PageTemplate
 <div id='sidebarTabs' role='complementary' refresh='content' force='true' tiddler='SideBarTabs'></div>
 </div>
 <div id='displayArea' role='main'>
-<div id='messageArea'></div>
+<div id='messageArea' class='messageArea'></div>
 <div id='tiddlerDisplay'></div>
 </div>
 <!--}}}-->

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -61,7 +61,9 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .wizard .gotFromServer {background:#80ffff;}
 
 .messageArea {border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]];}
-.messageToolbar__button {color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none;}
+.messageToolbar__button { color:[[ColorPalette::PrimaryMid]]; border:none; }
+.messageToolbar__icon { fill:[[ColorPalette::TertiaryDark]]; }
+.messageToolbar__icon:hover { fill:[[ColorPalette::Foreground]]; }
 
 .popupTiddler {background:[[ColorPalette::TertiaryPale]]; border:2px solid [[ColorPalette::TertiaryMid]];}
 

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -39,8 +39,8 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 #sidebarOptions .sliderPanel a:active {color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::Background]];}
 
 .wizard { background:[[ColorPalette::PrimaryPale]]; }
-.wizard h1 {color:[[ColorPalette::PrimaryDark]]; border:none;}
-.wizard h2 {color:[[ColorPalette::Foreground]]; border:none;}
+.wizard__title    { color:[[ColorPalette::PrimaryDark]]; border:none; }
+.wizard__subtitle { color:[[ColorPalette::Foreground]]; border:none; }
 .wizardStep { background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]]; }
 .wizardStep.wizardStepDone {background:[[ColorPalette::TertiaryLight]];}
 .wizardFooter {background:[[ColorPalette::PrimaryPale]];}

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -59,8 +59,10 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .wizard .putToServer {background:#ff80ff;}
 .wizard .gotFromServer {background:#80ffff;}
 
-.messageArea {border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]];}
-.messageToolbar__button { color:[[ColorPalette::PrimaryMid]]; border:none; }
+.messageArea { border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; }
+.messageToolbar__button { color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none; }
+.messageToolbar__button_withIcon { background:inherit; }
+.messageToolbar__button_withIcon:active { background:inherit; border:none; }
 .messageToolbar__icon { fill:[[ColorPalette::TertiaryDark]]; }
 .messageToolbar__icon:hover { fill:[[ColorPalette::Foreground]]; }
 

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -38,11 +38,10 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 #sidebarOptions .sliderPanel a:hover {color:[[ColorPalette::Background]]; background:[[ColorPalette::PrimaryMid]];}
 #sidebarOptions .sliderPanel a:active {color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::Background]];}
 
-.wizard {background:[[ColorPalette::PrimaryPale]]; border:1px solid [[ColorPalette::PrimaryMid]];}
+.wizard { background:[[ColorPalette::PrimaryPale]]; }
 .wizard h1 {color:[[ColorPalette::PrimaryDark]]; border:none;}
 .wizard h2 {color:[[ColorPalette::Foreground]]; border:none;}
-.wizardStep {background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]];
-	border:1px solid [[ColorPalette::PrimaryMid]];}
+.wizardStep { background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]]; }
 .wizardStep.wizardStepDone {background:[[ColorPalette::TertiaryLight]];}
 .wizardFooter {background:[[ColorPalette::PrimaryPale]];}
 .wizardFooter .status {background:[[ColorPalette::PrimaryDark]]; color:[[ColorPalette::Background]];}

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -60,8 +60,8 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .wizard .putToServer {background:#ff80ff;}
 .wizard .gotFromServer {background:#80ffff;}
 
-#messageArea {border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]];}
-#messageArea .button {color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none;}
+.messageArea {border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]];}
+.messageToolbar__button {color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none;}
 
 .popupTiddler {background:[[ColorPalette::TertiaryPale]]; border:2px solid [[ColorPalette::TertiaryMid]];}
 

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -77,8 +77,8 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .wizardFooter .status {padding:0 0.4em; margin-left:1em;}
 .wizard .button {padding:0.1em 0.2em;}
 
-.messageArea {position:fixed; top:2em; right:0; margin:0.5em; padding:0.5em; z-index:2000; _position:absolute;}
-.messageArea a {text-decoration:underline;}
+.messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
+.messageArea a { text-decoration:underline; }
 .messageToolbar { display:block; text-align:right; padding:0.2em; }
 .messageToolbar__icon { height: 1em; }
 

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -77,9 +77,9 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .wizardFooter .status {padding:0 0.4em; margin-left:1em;}
 .wizard .button {padding:0.1em 0.2em;}
 
-#messageArea {position:fixed; top:2em; right:0; margin:0.5em; padding:0.5em; z-index:2000; _position:absolute;}
+.messageArea {position:fixed; top:2em; right:0; margin:0.5em; padding:0.5em; z-index:2000; _position:absolute;}
 .messageToolbar {display:block; text-align:right; padding:0.2em;}
-#messageArea a {text-decoration:underline;}
+.messageArea a {text-decoration:underline;}
 
 .tiddlerPopupButton {padding:0.2em;}
 .popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -69,8 +69,9 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 #sidebarTabs .tabContents {width:15em; overflow:hidden;}
 
 .wizard {padding:0.1em 1em 0 2em;}
-.wizard h1 {font-size:2em; font-weight:bold; background:none; padding:0; margin:0.4em 0 0.2em;}
-.wizard h2 {font-size:1.2em; font-weight:bold; background:none; padding:0; margin:0.4em 0 0.2em;}
+.wizard__title { font-size:2em; }
+.wizard__subtitle { font-size:1.2em; }
+.wizard__title, .wizard__subtitle { font-weight:bold; background:none; padding:0; margin:0.4em 0 0.2em; }
 .wizardStep {padding:1em 1em 1em 1em;}
 .wizard .button {margin:0.5em 0 0; font-size:1.2em;}
 .wizardFooter {padding:0.8em 0.4em 0.8em 0;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -68,15 +68,14 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 #sidebarOptions .sliderPanel input {margin:0 0 0.3em 0;}
 #sidebarTabs .tabContents {width:15em; overflow:hidden;}
 
-.wizard {padding:0.1em 1em 0 2em;}
-.wizard__title { font-size:2em; }
+.wizard { padding:0.1em 2em 0; }
+.wizard__title    { font-size:2em; }
 .wizard__subtitle { font-size:1.2em; }
 .wizard__title, .wizard__subtitle { font-weight:bold; background:none; padding:0; margin:0.4em 0 0.2em; }
-.wizardStep {padding:1em 1em 1em 1em;}
-.wizard .button {margin:0.5em 0 0; font-size:1.2em;}
-.wizardFooter {padding:0.8em 0.4em 0.8em 0;}
-.wizardFooter .status {padding:0 0.4em; margin-left:1em;}
-.wizard .button {padding:0.1em 0.2em;}
+.wizardStep { padding:1em; }
+.wizardFooter { padding:0.8em 0.4em 0.8em 0; }
+.wizardFooter .status { padding:0.2em 0.7em; margin-left:0.3em; }
+.wizardFooter .button { margin:0.5em 0 0; font-size:1.2em; padding:0.2em 0.5em; }
 
 .messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
 .messageArea a { text-decoration:underline; }
@@ -163,7 +162,7 @@ table.listView th, table.listView td, table.listView tr {padding:0 3px 0 3px;}
 #backstageButton {display:none; position:absolute; z-index:175; top:0; right:0;}
 #backstageButton a {padding:0.1em 0.4em; margin:0.1em;}
 #backstage {position:relative; width:100%; z-index:50;}
-#backstagePanel {display:none; z-index:100; position:absolute; width:90%; margin-left:3em; padding:1em;}
+#backstagePanel { display:none; z-index:100; position:absolute; width:90%; margin-left:3em; }
 .backstagePanelFooter {padding-top:0.2em; float:right;}
 .backstagePanelFooter a {padding:0.2em 0.4em;}
 #backstageCloak {display:none; z-index:20; position:absolute; width:100%; height:100px;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -78,8 +78,9 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .wizard .button {padding:0.1em 0.2em;}
 
 .messageArea {position:fixed; top:2em; right:0; margin:0.5em; padding:0.5em; z-index:2000; _position:absolute;}
-.messageToolbar {display:block; text-align:right; padding:0.2em;}
 .messageArea a {text-decoration:underline;}
+.messageToolbar { display:block; text-align:right; padding:0.2em; }
+.messageToolbar__icon { height: 1em; }
 
 .tiddlerPopupButton {padding:0.2em;}
 .popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -79,7 +79,7 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 
 .messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
 .messageArea a { text-decoration:underline; }
-.messageToolbar { display:block; text-align:right; padding:0.2em; }
+.messageToolbar { text-align:right; padding:0.2em 0; }
 .messageToolbar__icon { height: 1em; }
 
 .tiddlerPopupButton {padding:0.2em;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -78,9 +78,10 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .wizardFooter .button { margin:0.5em 0 0; font-size:1.2em; padding:0.2em 0.5em; }
 
 .messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
-.messageArea a { text-decoration:underline; }
 .messageToolbar { text-align:right; padding:0.2em 0; }
+.messageToolbar__button { text-decoration:underline; }
 .messageToolbar__icon { height: 1em; }
+.messageArea__text a { text-decoration:underline; }
 
 .tiddlerPopupButton {padding:0.2em;}
 .popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}

--- a/shadows/StyleSheetPrint.tid
+++ b/shadows/StyleSheetPrint.tid
@@ -2,7 +2,7 @@ title: StyleSheetPrint
 
 /*{{{*/
 @media print {
-#mainMenu, #sidebar, #messageArea, .toolbar, #backstageButton, #backstageArea {display: none !important;}
+#mainMenu, #sidebar, .messageArea, .toolbar, #backstageButton, #backstageArea {display: none !important;}
 #displayArea {margin: 1em 1em 0em;}
 noscript {display:none;} /* Fixes a feature in Firefox 1.5.0.2 where print preview displays the noscript content */
 }


### PR DESCRIPTION
This branch contains:
* codestyle improvements in Backstage.js, Lingo.js, Wizard.js, 
* improvements of styling (markup and CSS) of messageArea, backstage, wizard
  * refactor using [BEM](https://en.bem.info/) (naming convention: blockName, blockName__elementName, blockName_modifierName, blockName_modifierName-modifierValue, the latter not used yet)
  * during refactoring, removed a hack for IE 5, 6 and `display: block;` for a `div`
  * backstage and wizard: remove multiple borders/colorful paddings and make padding of wizard symmetric; increase paddings of buttons and status messages in footer
  * messageArea: substitute "close" text with SVG icon but allow to fallback (controlled by `chkDontUseSvgIcons` option); align the button to the right (without awkward horizontal padding)
* shortened `mainSaved` message from "Main TiddlyWiki file saved" to "TiddlyWiki saved"

some screenshots:
was:
![image](https://user-images.githubusercontent.com/1131924/52300886-183f1300-299a-11e9-99b8-b142d1b7cf96.png)
became:
![image](https://user-images.githubusercontent.com/1131924/52300940-360c7800-299a-11e9-8f38-2b9dddc6bd21.png)

was:
![image](https://user-images.githubusercontent.com/1131924/52301256-13c72a00-299b-11e9-92c8-45aa84a6854b.png)
became:
![image](https://user-images.githubusercontent.com/1131924/52301306-36f1d980-299b-11e9-99cc-0f6c7421b205.png)
![image](https://user-images.githubusercontent.com/1131924/52301311-3ce7ba80-299b-11e9-92df-d152d00f728d.png)
with `config.options.chkDontUseSvgIcons = true`:
![image](https://user-images.githubusercontent.com/1131924/52301388-5db01000-299b-11e9-8424-3a603cbeacb2.png)
