### PR TITLE
Fix compability with custom PageTemplate (remove "fanatical" BEM usage bits)

### DIFF
--- a/shadows/PageTemplate.tid
+++ b/shadows/PageTemplate.tid
@@ -17,7 +17,7 @@ title: PageTemplate
 <div id='sidebarTabs' role='complementary' refresh='content' force='true' tiddler='SideBarTabs'></div>
 </div>
 <div id='displayArea' role='main'>
-<div id='messageArea' class='messageArea'></div>
+<div id='messageArea'></div>
 <div id='tiddlerDisplay'></div>
 </div>
 <!--}}}-->

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -59,7 +59,7 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .wizard .putToServer {background:#ff80ff;}
 .wizard .gotFromServer {background:#80ffff;}
 
-.messageArea { border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; }
+#messageArea { border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; }
 .messageToolbar__button { color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none; }
 .messageToolbar__button_withIcon { background:inherit; }
 .messageToolbar__button_withIcon:active { background:inherit; border:none; }

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -77,7 +77,7 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .wizardFooter .status { padding:0.2em 0.7em; margin-left:0.3em; }
 .wizardFooter .button { margin:0.5em 0 0; font-size:1.2em; padding:0.2em 0.5em; }
 
-.messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
+#messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
 .messageToolbar { text-align:right; padding:0.2em 0; }
 .messageToolbar__button { text-decoration:underline; }
 .messageToolbar__icon { height: 1em; }

--- a/shadows/StyleSheetPrint.tid
+++ b/shadows/StyleSheetPrint.tid
@@ -2,7 +2,7 @@ title: StyleSheetPrint
 
 /*{{{*/
 @media print {
-#mainMenu, #sidebar, .messageArea, .toolbar, #backstageButton, #backstageArea {display: none !important;}
+#mainMenu, #sidebar, #messageArea, .toolbar, #backstageButton, #backstageArea {display: none !important;}
 #displayArea {margin: 1em 1em 0em;}
 noscript {display:none;} /* Fixes a feature in Firefox 1.5.0.2 where print preview displays the noscript content */
 }


### PR DESCRIPTION
Using class selectors introduced into PageTemplate is not safe yet since PageTemplate may be customized (see problem reported by James fallwest1 and Reto [here](https://groups.google.com/forum/#!topic/tiddlywikiclassic/GDBYezPtdlg)). Either the class should be added via JS or it should be made *very* clear for users who use customized PageTemplate that it should be updated (definitely not for the current release), or it should be updated automatically by the core