### PR TITLE
fix version detection for the next release

### DIFF
--- a/js/Upgrade.js
+++ b/js/Upgrade.js
@@ -101,7 +101,7 @@ config.macros.upgrade.onCancel = function(e)
 
 config.macros.upgrade.extractVersion = function(upgradeFile)
 {
-	var re = /^var version = \{title: "([^"]+)", major: (\d+), minor: (\d+), revision: (\d+)(, beta: (\d+)){0,1}, date: new Date\("([^"]+)"\)/mg;
+	var re = /^var version = \{\s*title: "([^"]+)", major: (\d+), minor: (\d+), revision: (\d+)(, beta: (\d+)){0,1}, date: new Date\("([^"]+)"\)/mg;
 	var m = re.exec(upgradeFile);
 	return m ? {title: m[1], major: m[2], minor: m[3], revision: m[4], beta: m[6], date: new Date(m[7])} : null;
 };

--- a/js/Version.js
+++ b/js/Version.js
@@ -1,1 +1,1 @@
-var version = { title: "TiddlyWiki", major: 2, minor: 9, revision: 2, date: new Date("February 12, 2019"), extensions: {} };
+var version = {title: "TiddlyWiki", major: 2, minor: 9, revision: 2, date: new Date("February 12, 2019"), extensions: {}};


### PR DESCRIPTION
When upgrading the version number from 2.9.1 to 2.9.2, I've added whitespace which actually prevented upgrading from working properly due to strict RegExp for version detection. To make upgrading work (from 2.9.2 where upgrading got fixed) for the next release, I've removed the whitespace back, but also made the version detection tolerate whitespace if it gets added again (incidentally or intentionally)