### PR TITLE
fix paddings in tags chooser when there are no tags to display

### DIFF
--- a/js/Macros.js
+++ b/js/Macros.js
@@ -517,7 +517,7 @@ config.macros.tagChooser.onClick = function(ev)
 	var popup = Popup.create(this);
 	var tags = store.getTags(this.getAttribute("tags"));
 	if(tags.length == 0)
-		jQuery("<li/>").text(lingo.popupNone).appendTo(popup);
+		jQuery("<li/>").addClass('disabled').text(lingo.popupNone).appendTo(popup);
 
 	for(var t = 0; t < tags.length; t++) {
 		var tag = createTiddlyButton(createTiddlyElement(popup,"li"),tags[t][0],lingo.tagTooltip.format([tags[t][0]]),config.macros.tagChooser.onTagClick);


### PR DESCRIPTION
Because of no `disabled` tag, tag chooser is shown without paddings when there's no tags to suggest:
![image](https://user-images.githubusercontent.com/1131924/55686872-3d86d800-596f-11e9-920b-cef912cf5540.png)
Adding the tag fixes paddings:
![image](https://user-images.githubusercontent.com/1131924/55686888-7161fd80-596f-11e9-9f04-08d9b1728936.png)
To do: improve typography of `.popup` (border → shadow, ...)