### PR TITLE
Improve typographics of hovering elements

### DIFF
--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -74,7 +74,7 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 
 .popupTiddler {background:[[ColorPalette::TertiaryPale]]; border:2px solid [[ColorPalette::TertiaryMid]];}
 
-.popup {background:[[ColorPalette::TertiaryPale]]; color:[[ColorPalette::TertiaryDark]]; border-left:1px solid [[ColorPalette::TertiaryMid]]; border-top:1px solid [[ColorPalette::TertiaryMid]]; border-right:2px solid [[ColorPalette::TertiaryDark]]; border-bottom:2px solid [[ColorPalette::TertiaryDark]];}
+.popup { background:[[ColorPalette::TertiaryPale]]; color:[[ColorPalette::TertiaryDark]]; box-shadow: 1px 2px 5px [[ColorPalette::TertiaryMid]]; }
 .popup hr {color:[[ColorPalette::PrimaryDark]]; background:[[ColorPalette::PrimaryDark]]; border-bottom:1px;}
 .popup li.disabled {color:[[ColorPalette::TertiaryMid]];}
 .popup li a, .popup li a:visited {color:[[ColorPalette::Foreground]]; border: none;}

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -65,7 +65,7 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .wizard .putToServer {background:#ff80ff;}
 .wizard .gotFromServer {background:#80ffff;}
 
-#messageArea { border:1px solid [[ColorPalette::SecondaryMid]]; background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; }
+#messageArea { background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; box-shadow: 1px 2px 5px [[ColorPalette::TertiaryMid]]; }
 .messageToolbar__button { color:[[ColorPalette::PrimaryMid]]; background:[[ColorPalette::SecondaryPale]]; border:none; }
 .messageToolbar__button_withIcon { background:inherit; }
 .messageToolbar__button_withIcon:active { background:inherit; border:none; }

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -72,16 +72,18 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .messageToolbar__icon { fill:[[ColorPalette::TertiaryDark]]; }
 .messageToolbar__icon:hover { fill:[[ColorPalette::Foreground]]; }
 
-.popupTiddler {background:[[ColorPalette::TertiaryPale]]; border:2px solid [[ColorPalette::TertiaryMid]];}
-
 .popup { background:[[ColorPalette::TertiaryPale]]; color:[[ColorPalette::TertiaryDark]]; box-shadow: 1px 2px 5px [[ColorPalette::TertiaryMid]]; }
-.popup hr {color:[[ColorPalette::PrimaryDark]]; background:[[ColorPalette::PrimaryDark]]; border-bottom:1px;}
-.popup li.disabled {color:[[ColorPalette::TertiaryMid]];}
-.popup li a, .popup li a:visited {color:[[ColorPalette::Foreground]]; border: none;}
-.popup li a:hover {background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; border: none;}
-.popup li a:active {background:[[ColorPalette::SecondaryPale]]; color:[[ColorPalette::Foreground]]; border: none;}
+.popup li a, .popup li a:visited, .popup li a:hover, .popup li a:active {
+	color:[[ColorPalette::Foreground]]; border: none;
+}
+.popup li a:hover { background:[[ColorPalette::SecondaryLight]]; }
+.popup li a:active { background:[[ColorPalette::SecondaryPale]]; }
+.popup li.disabled { color:[[ColorPalette::TertiaryMid]]; }
 .popupHighlight {background:[[ColorPalette::Background]]; color:[[ColorPalette::Foreground]];}
+.popup hr {color:[[ColorPalette::PrimaryDark]]; background:[[ColorPalette::PrimaryDark]]; border-bottom:1px;}
 .listBreak div {border-bottom:1px solid [[ColorPalette::TertiaryDark]];}
+
+.popupTiddler {background:[[ColorPalette::TertiaryPale]]; border:2px solid [[ColorPalette::TertiaryMid]];}
 
 .tiddler .defaultCommand {font-weight:bold;}
 

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -84,15 +84,15 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .messageToolbar__icon { height: 1em; }
 .messageArea__text a { text-decoration:underline; }
 
-.tiddlerPopupButton {padding:0.2em;}
-.popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}
-
 .popup {position:absolute; z-index:300; font-size:.9em; padding:0.3em 0; list-style:none; margin:0;}
 .popup .popupMessage, .popup li.disabled, .popup li a { padding: 0.3em 0.7em; }
 .popup li a {display:block; font-weight:normal; cursor:pointer;}
 .popup hr {display:block; height:1px; width:auto; padding:0; margin:0.2em 0;}
 .listBreak {font-size:1px; line-height:1px;}
 .listBreak div {margin:2px 0;}
+
+.tiddlerPopupButton {padding:0.2em;}
+.popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}
 
 .tabset {padding:1em 0 0 0.5em;}
 .tab {margin:0 0 0 0.25em; padding:2px;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -87,11 +87,10 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .tiddlerPopupButton {padding:0.2em;}
 .popupTiddler {position: absolute; z-index:300; padding:1em; margin:0;}
 
-.popup {position:absolute; z-index:300; font-size:.9em; padding:0; list-style:none; margin:0;}
-.popup .popupMessage {padding:0.4em;}
+.popup {position:absolute; z-index:300; font-size:.9em; padding:0.3em 0; list-style:none; margin:0;}
+.popup .popupMessage, .popup li.disabled, .popup li a { padding: 0.3em 0.7em; }
+.popup li a {display:block; font-weight:normal; cursor:pointer;}
 .popup hr {display:block; height:1px; width:auto; padding:0; margin:0.2em 0;}
-.popup li.disabled {padding:0.4em;}
-.popup li a {display:block; padding:0.4em; font-weight:normal; cursor:pointer;}
 .listBreak {font-size:1px; line-height:1px;}
 .listBreak div {margin:2px 0;}
 


### PR DESCRIPTION
These changes substitute borders of messageArea
![image](https://user-images.githubusercontent.com/1131924/56865351-b8269e80-69d5-11e9-828b-fa0d4da93f7a.png)
with shadows
![image](https://user-images.githubusercontent.com/1131924/56865354-c2489d00-69d5-11e9-95cb-93653041ed75.png)
and also does the same to popups and changes their paddings:
![image](https://user-images.githubusercontent.com/1131924/56866441-d4303d00-69e1-11e9-8be6-5d92eb05bd44.png)
![image](https://user-images.githubusercontent.com/1131924/56866452-f629bf80-69e1-11e9-963a-60f76f444967.png)
and paired with previous changes, updates "no tags yet" popup in the following way:
![image](https://user-images.githubusercontent.com/1131924/56866469-28d3b800-69e2-11e9-902b-ee6c34c92edc.png)
