### PR TITLE
Enable "open in new tab" for prettyLinks

### DIFF
--- a/js/Commands.js
+++ b/js/Commands.js
@@ -66,9 +66,9 @@ config.commands.deleteTiddler.handler = function(event,src,title)
 
 config.commands.permalink.handler = function(event,src,title)
 {
-	var t = encodeURIComponent(String.encodeTiddlyLink(title));
-	if(window.location.hash != t)
-		window.location.hash = t;
+	var hash = story.getPermaViewHash([title]);
+	if(window.location.hash != hash)
+		window.location.hash = hash;
 	return false;
 };
 

--- a/js/Story.js
+++ b/js/Story.js
@@ -625,17 +625,23 @@ Story.prototype.saveTiddler = function(title,minorUpdate)
 	return newTitle;
 };
 
-Story.prototype.permaView = function()
+Story.prototype.getPermaViewHash = function(titles)
 {
 	var links = [];
+	for(var i = 0; i < titles.length; i++)
+		links.push(String.encodeTiddlyLink(titles[i]));
+	return '#' + encodeURIComponent(links.join(' '));
+};
+
+Story.prototype.permaView = function()
+{
+	var titles = [];
 	this.forEachTiddler(function(title,element) {
-		links.push(String.encodeTiddlyLink(title));
+		titles.push(title);
 	});
-	var t = encodeURIComponent(links.join(" "));
-	if(t == "")
-		t = "#";
-	if(window.location.hash != t)
-		window.location.hash = t;
+	var hash = this.getPermaViewHash(titles);
+	if(window.location.hash != hash)
+		window.location.hash = hash;
 };
 
 Story.prototype.switchTheme = function(theme)

--- a/js/Utilities.js
+++ b/js/Utilities.js
@@ -211,6 +211,11 @@ function onClickTiddlerLink(ev)
 	return false;
 }
 
+function getTiddlerLinkHref(title)
+{
+	return window.location.toString().replace(/#.*$/,'') + story.getPermaViewHash([title]);
+}
+
 //# Create a link to a particular tiddler
 //#   place - element where the link should be created
 //#   title - title of target tiddler
@@ -223,7 +228,11 @@ function createTiddlyLink(place,title,includeText,className,isStatic,linkedFromT
 	var title = jQuery.trim(title);
 	var text = includeText ? title : null;
 	var i = getTiddlyLinkInfo(title,className);
-	var btn = isStatic ? createExternalLink(place,store.getTiddlerText("SiteUrl",null) + "#" + title) : createTiddlyButton(place,text,i.subTitle,onClickTiddlerLink,i.classes);
+	var btn = isStatic ?
+		createExternalLink(place, store.getTiddlerText("SiteUrl",null) + story.getPermaViewHash([title])) :
+		createTiddlyButton(place, text, i.subTitle, onClickTiddlerLink, i.classes, '', '', {
+			href: getTiddlerLinkHref(title)
+		});
 	if(isStatic)
 		btn.className += ' ' + className;
 	btn.setAttribute("refresh","link");


### PR DESCRIPTION
This set of changes introduces a helper for getting permalink/permaview url (`Story.prototype.getPermaViewHash`) and adds `href` attribute to prettyLinks so that right click works with them like with usual links and one can select "open in new tab" action