### PR TITLE
Remove borders from tagged/tagging (tiddler hover) and annotations

### DIFF
--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -97,8 +97,8 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .selected .toolbar a {color:[[ColorPalette::TertiaryMid]];}
 .selected .toolbar a:hover {color:[[ColorPalette::Foreground]];}
 
-.tagging, .tagged {border:1px solid [[ColorPalette::TertiaryPale]]; background-color:[[ColorPalette::TertiaryPale]];}
-.selected .tagging, .selected .tagged {background-color:[[ColorPalette::TertiaryLight]]; border:1px solid [[ColorPalette::TertiaryMid]];}
+.tagging, .tagged { border: 1px solid [[ColorPalette::TertiaryPale]]; background-color: [[ColorPalette::TertiaryPale]]; }
+.selected .tagging, .selected .tagged { background-color: [[ColorPalette::TertiaryLight]]; border: 1px solid [[ColorPalette::TertiaryLight]]; }
 .tagging .listTitle, .tagged .listTitle {color:[[ColorPalette::PrimaryDark]];}
 .tagging .button, .tagged .button {border:none;}
 

--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -113,7 +113,7 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 
 .imageLink, #displayArea .imageLink {background:transparent;}
 
-.annotation {background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; border:2px solid [[ColorPalette::SecondaryMid]];}
+.annotation { background:[[ColorPalette::SecondaryLight]]; color:[[ColorPalette::Foreground]]; }
 
 .viewer .listTitle {list-style-type:none; margin-left:-2em;}
 .viewer .button {border:1px solid [[ColorPalette::SecondaryMid]];}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -129,7 +129,7 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 .footer {font-size:.9em;}
 .footer li {display:inline;}
 
-.annotation {padding:0.5em; margin:0.5em;}
+.annotation { padding: 0.5em 0.8em; margin: 0.5em 1px; }
 
 * html .viewer pre {width:99%; padding:0 0 1em 0;}
 .viewer {line-height:1.4em; padding-top:0.5em;}


### PR DESCRIPTION
While borders were "removed" (hidden by assigning color to that of background) for tagged/tagging blocks previously:
![image](https://user-images.githubusercontent.com/1131924/58130538-e8eca300-7c24-11e9-8677-3d376e8ccf7b.png)
they were not removed for "selected" (hovered) tiddlers:
![image](https://user-images.githubusercontent.com/1131924/58130591-0ae62580-7c25-11e9-89d5-3c26047fd31a.png)
The first commit fixes that:
![image](https://user-images.githubusercontent.com/1131924/58130773-9790e380-7c25-11e9-98b6-370a3caf03c5.png)

The second one takes care of annotations:
![image](https://user-images.githubusercontent.com/1131924/58130934-ffdfc500-7c25-11e9-82a0-5ad356a7474f.png)
becomes
![image](https://user-images.githubusercontent.com/1131924/58130942-04a47900-7c26-11e9-8c09-5850986e0e87.png)
