### PR TITLE
fix close message icon ~padding for IE

### DIFF
--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -81,7 +81,7 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 #messageArea { position:fixed; top:2em; right:0; margin:0.5em; padding:0.7em 1em; z-index:2000; }
 .messageToolbar { text-align:right; padding:0.2em 0; }
 .messageToolbar__button { text-decoration:underline; }
-.messageToolbar__icon { height: 1em; }
+.messageToolbar__icon { height: 1em; width: 1em; } /* width for IE */
 .messageArea__text a { text-decoration:underline; }
 
 .popup {position:absolute; z-index:300; font-size:.9em; padding:0.3em 0; list-style:none; margin:0;}


### PR DESCRIPTION
without specified width, IE (11) turns a cross image into something like this:

![image](https://user-images.githubusercontent.com/1131924/59542918-fd187d00-8f10-11e9-9613-ae7922ccb3ab.png)

hence the fix (those are no paddings actually, but rather internal area of the element)