### PR TITLE
fix various broken links and images, including http schema; improve text of Image Formatting tiddler

### DIFF
--- a/content/Advanced%20download%20options.tid
+++ b/content/Advanced%20download%20options.tid
@@ -9,11 +9,11 @@ type: text/x-tiddlywiki
 When you click on the [[download|Download]] button, the website will detect your browser and operating system, and trigger a download for either an empty ~TiddlyWiki file or, if you're running [[Safari]] or [[Opera]], a zip file which also includes the TiddlySaver file. This is version <<version>> of ~TiddlyWiki.
 
 Advanced users may find these download options helpful (right click the link and select "Save as" to download):
-*[[An empty TiddlyWiki file|http://www.tiddlywiki.com/empty.html]]
-*[[A zip file containing an empty TiddlyWiki file plus a TiddlySaver file|http://www.tiddlywiki.com/empty.zip]]
-*[[A copy of this website (TiddlyWiki.com) minus images|#]]
-*[[The TiddlySaver.jar file on its own|http://www.tiddlywiki.com/TiddlySaver.jar]]
+* [[An empty TiddlyWiki file|./empty.html]]
+* [[A zip file containing an empty TiddlyWiki file plus a TiddlySaver file|./empty.zip]]
+* [[A copy of this website (TiddlyWiki.com) minus images|#]]
+* [[The TiddlySaver.jar file on its own|./TiddlySaver.jar]]
 Finally, these links may be useful:
-*[[Downloading]] instructions for the main browsers
-*A list of supported [[Browsers]]
-*Archive of older versions of TiddlyWiki at http://tiddlywiki.com/archive/
+* [[Downloading]] instructions for the main browsers
+* A list of supported [[Browsers]]
+* Archive of older versions of TiddlyWiki in the [[archive|./archive/]]

--- a/content/Browsers.tid
+++ b/content/Browsers.tid
@@ -19,4 +19,4 @@ See also the [[TiddlyWiki apps available for smartphones|MobileDevices]].
 
 
 
-Please [[let us know|http://groups.google.com/group/TiddlyWiki]] of any additions or corrections.
+Please [[let us know|https://groups.google.com/group/TiddlyWikiClassic]] of any additions or corrections.

--- a/content/Community.tid
+++ b/content/Community.tid
@@ -6,7 +6,7 @@ tags: community help
 title: Community
 type: text/x-tiddlywiki
 
-[>img[tiddlywiki.org logo|http://trac.tiddlywiki.org/chrome/site/tworg_logo_med.jpg][http://www.tiddlywiki.org]]~TiddlyWiki today is the result of the efforts of dozens of people around the world generously contributing their time and skill, and offering considerable help and support. 
+[>img[tiddlywiki.org logo|//trac.tiddlywiki.org/chrome/site/tworg_logo_med.jpg][http://www.tiddlywiki.org]]~TiddlyWiki today is the result of the efforts of dozens of people around the world generously contributing their time and skill, and offering considerable help and support.
 
 The community has several hubs for different activities:
 * The DiscussionForums on Google Groups
@@ -14,6 +14,6 @@ The community has several hubs for different activities:
 * TiddlyWiki code at http://github.com/TiddlyWiki/tiddlywiki
 * TiddlyWiki issue tracker at https://github.com/TiddlyWiki/tiddlywiki/issues
 * The community wiki at http://tiddlywiki.org/
-* TiddlyWiki development resources at http://tiddlywiki.com/dev/
+* TiddlyWiki development resources at https://classic.tiddlywiki.com/dev/
 
 The community welcomes [[contributions|Contribute]].

--- a/content/DiscussionForums.tid
+++ b/content/DiscussionForums.tid
@@ -7,10 +7,10 @@ title: DiscussionForums
 type: text/x-tiddlywiki
 
 There are two Google Group discussion forums for discussions about ~TiddlyWiki, whether basic entry level questions or more complex development challenges. They are the best places to ask questions about ~TiddlyWiki, and to connect with other enthusiasts:
-* A ~TiddlyWiki group for general discussion, bug reports and announcements at http://groups.google.com/group/TiddlyWiki
-* A ~TiddlyWikiDev group for discussion about ~TiddlyWiki development at http://groups.google.com/group/TiddlyWikiDev
+* A ~TiddlyWikiClassic group for general discussion, bug reports and announcements at https://groups.google.com/group/TiddlyWikiClassic
+* A ~TiddlyWikiDev group for discussion about ~TiddlyWiki development at https://groups.google.com/group/TiddlyWikiDev
 !~Non-English resources
 There are a number of resources for non-English language speakers:
-* ~TiddlyWikiFR, in French, at http://groups.google.com/group/TiddlyWikiFR
-* ~TiddlyWiki 華語支援論壇, in Chinese, at http://groups.google.com/group/TiddlyWiki-zh
-* A guide to [[TiddlyWiki in Japanese|http://www.geocities.jp/potto372/tiddlywiki/tiddlywikinote.html]]
+* ~TiddlyWikiFR, in French, at https://groups.google.com/group/TiddlyWikiFR
+* ~TiddlyWiki 華語支援論壇, in Chinese, at https://groups.google.com/group/TiddlyWiki-zh
+* A guide to [[TiddlyWiki in Japanese|http://web.archive.org/web/20181105134952/https://www.geocities.jp/potto372/tiddlywiki/tiddlywikinote.html]]

--- a/content/DownloadTiddlyWikiPlugin.tid
+++ b/content/DownloadTiddlyWikiPlugin.tid
@@ -11,7 +11,7 @@ type: text/x-tiddlywiki
 |''Description:''|Download TiddlyWiki according to browser type|
 |''Version:''|0.0.9|
 |''Date:''|Jul 18, 2012|
-|''Source:''|http://www.tiddlywiki.com/#DownloadTiddlyWikiPlugin|
+|''Source:''|https://classic.tiddlywiki.com/#DownloadTiddlyWikiPlugin|
 |''License:''|[[BSD open source license]]|
 |''~CoreVersion:''|2.4.1|
 ***/

--- a/content/Downloading%20guidelines%3A%20Opera%20on%20Mac%20OS%20X.tid
+++ b/content/Downloading%20guidelines%3A%20Opera%20on%20Mac%20OS%20X.tid
@@ -17,7 +17,7 @@ Open the zip file, and then check in the resulting folder that you have automati
 *empty.html (this is your ~TiddlyWiki file)
 *~TiddlySaver.jar (this is a java applet, which will make sure everything works in your chosen browser. Note a copy of this file ''must'' be kept in the same folder as any ~TiddlyWiki file you are using) 
 [img[images/step2macopera.jpg]]
-You can download the TiddlySaver file on it's own from [[here|http://www.tiddlywiki.com/TiddlySaver.jar]] if you need it.
+You can download the TiddlySaver file on it's own from [[here|./TiddlySaver.jar]] if you need it.
 
 Open the empty.html file to get started.
 !Step 3 - Trust applet

--- a/content/Downloading%20guidelines%3A%20Safari%20on%20Mac%20OS%20X.tid
+++ b/content/Downloading%20guidelines%3A%20Safari%20on%20Mac%20OS%20X.tid
@@ -13,7 +13,7 @@ After [[Download]], check first that you have automatically received a zip file 
 *empty.html (this is your ~TiddlyWiki file)
 *~TiddlySaver.jar (this is a java applet, which will make sure everything works in your chosen browser. Note a copy of this file ''must'' be kept in the same folder as any ~TiddlyWiki file you are using) 
 [img[images/step1macsafari.jpg]]
-You can download the ~TiddlySaver.jar file on it's own from [[here|http://www.tiddlywiki.com/TiddlySaver.jar]] if you need it.
+You can download the ~TiddlySaver.jar file on it's own from [[here|./TiddlySaver.jar]] if you need it.
 
 Double click the empty.html file to get started.
 !Step 2 - Open file

--- a/content/ExamplePlugin.tid
+++ b/content/ExamplePlugin.tid
@@ -11,7 +11,7 @@ type: text/x-tiddlywiki
 |''Description:''|To demonstrate how to write TiddlyWiki plugins|
 |''Version:''|2.0.3|
 |''Date:''|Sep 22, 2006|
-|''Source:''|http://www.tiddlywiki.com/#ExamplePlugin|
+|''Source:''|https://classic.tiddlywiki.com/#ExamplePlugin|
 |''Author:''|JeremyRuston (jeremy (at) osmosoft (dot) com)|
 |''License:''|[[BSD open source license]]|
 |''~CoreVersion:''|2.1.0|

--- a/content/FlickrBadge.tid
+++ b/content/FlickrBadge.tid
@@ -10,14 +10,14 @@ Here's one way to get a Flickr badge in TiddlyWiki:
 
 <html>
 <a href="http://www.flickr.com" style="text-align:center;">www.<strong style="color:#3993ff">flick<span style="color:#ff1c92">r</span></strong>.com</a><br>
-<iframe style="background-color:#ffffff; border-color:#ffffff; border:none;" width="113" height="151" frameborder="0" scrolling="no" src="http://www.flickr.com/apps/badge/badge_iframe.gne?zg_bg_color=ffffff&zg_person_id=35468148136%40N01" title="Flickr Badge"></iframe>
+<iframe style="background-color:#ffffff; border-color:#ffffff; border:none;" width="113" height="151" frameborder="0" scrolling="no" src="//www.flickr.com/apps/badge/badge_iframe.gne?zg_bg_color=ffffff&zg_person_id=35468148136%40N01" title="Flickr Badge"></iframe>
 </html>
 
 Here's the HTML code to insert in a tiddler:
 {{{
 <html>
 <a href="http://www.flickr.com" style="text-align:center;">www.<strong style="color:#3993ff">flick<span style="color:#ff1c92">r</span></strong>.com</a><br>
-<iframe style="background-color:#ffffff; border-color:#ffffff; border:none;" width="113" height="151" frameborder="0" scrolling="no" src="http://www.flickr.com/apps/badge/badge_iframe.gne?zg_bg_color=ffffff&zg_person_id=35468148136%40N01" title="Flickr Badge"></iframe>
+<iframe style="background-color:#ffffff; border-color:#ffffff; border:none;" width="113" height="151" frameborder="0" scrolling="no" src="//www.flickr.com/apps/badge/badge_iframe.gne?zg_bg_color=ffffff&zg_person_id=35468148136%40N01" title="Flickr Badge"></iframe>
 </html>
 }}}
 

--- a/content/HostedOptions.tid
+++ b/content/HostedOptions.tid
@@ -8,13 +8,13 @@ type: text/x-tiddlywiki
 There are several ways that you can have your TiddlyWiki data hosted online, making it easier to access and share your information.
 
 !~TiddlySpot
-[<img[http://tiddlyspot.com/_ts/images/banner-logo.png][TiddlySpot|http://tiddlyspot.com]] ~TiddlySpot lets you put TiddlyWiki documents on the Web, and edit them directly in your browser. It doesn't yet offer full support for simultaneous editing by multiple users.
+[<img[//tiddlyspot.com/_ts/images/banner-logo.png][TiddlySpot|http://tiddlyspot.com]] ~TiddlySpot lets you put TiddlyWiki documents on the Web, and edit them directly in your browser. It doesn't yet offer full support for simultaneous editing by multiple users.
 
 !~DropBox
 Many people use [[DropBox|http://dropbox.com]] to synchronise their TiddlyWiki documents to make them available on multiple computers. The ~DropBox iPhone/iPad application also permits read only access to TiddlyWiki documents. See [[A Personal Knowledgebase Solution: Tiddlywiki and Dropbox|http://www.broowaha.com/articles/7671/a-personal-knowledgebase-solution-tiddlywiki-and-dropbox]]
 
 !~TiddlyWeb & ~TiddlySpace
-[<img[TiddlySpace|http://tiddlyspace.com/bags/frontpage_public/tiddlers/shinyspace.png][http://tiddlyspace.com]] [[TiddlySpace|http://tiddlyspace.com]] is a full hosted service for TiddlyWiki that allows multiple people to edit the same wiki at the same time. It is particularly focussed on sharing tiddlers.
+[<img[TiddlySpace|//tiddlyspace.com/bags/frontpage_public/tiddlers/shinyspace.png][http://tiddlyspace.com]] [[TiddlySpace|http://tiddlyspace.com]] is a full hosted service for TiddlyWiki that allows multiple people to edit the same wiki at the same time. It is particularly focussed on sharing tiddlers.
 
 ~TiddlySpace is built on top of [[TiddlyWeb|http://tiddlyweb.com]], a flexible architecture for putting tiddlers on the web.
 

--- a/content/HowToUpgradeOlderTiddlyWikis.tid
+++ b/content/HowToUpgradeOlderTiddlyWikis.tid
@@ -8,7 +8,7 @@ type: text/x-tiddlywiki
 
 The steps you need to take depend on which version of TiddlyWiki you are upgrading from. From version 2.4.0 onwards, you can upgrade to the latest version using the 'Upgrade' tab in the BackstageArea, as described in HowToUpgrade. If you're using an earlier version of TiddlyWiki, you'll need to follow these instructions instead:
 ! Upgrading from TiddlyWiki earlier than version 2.4.0 to the latest version
-* Download a fresh, empty version of TiddlyWiki by right-clicking on [[this link|http://www.tiddlywiki.com/empty.html]], selecting 'Save target' or 'Save link' and saving it in a convenient location as (say) "mynewtiddlywiki.html"
+* Download a fresh, empty version of TiddlyWiki by right-clicking on [[this link|./empty.html]], selecting 'Save target' or 'Save link' and saving it in a convenient location as (say) "mynewtiddlywiki.html"
 * Open the new TiddlyWiki file in your browser
 * Choose ''import'' from the BackstageArea at the top of the window (you may need to click the 'backstage' button at the upper right to show the BackstageArea)
 * Click the ''browse'' button and select your original TiddlyWiki file (say, "mytiddlywiki.html") from the file browser

--- a/content/Image%20Formatting.tid
+++ b/content/Image%20Formatting.tid
@@ -8,35 +8,35 @@ type: text/x-tiddlywiki
 
 !Simple Images
 {{{
-[img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+[img[https://classic.tiddlywiki.com/images/fractalveg.jpg]]
 }}}
 Displays as:
-[img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+[img[https://classic.tiddlywiki.com/images/fractalveg.jpg]]
 !Tooltips for Images
 {{{
-[img[tooltip|http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+[img[tooltip|images/fractalveg.jpg]]
 }}}
-Displays as:
-[img[tooltip|http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+Shows a toolitp if one hovers mouse over the image:
+[img[tooltip|images/fractalveg.jpg]]
 !Image Links
 {{{
-[img[http://wikitext.tiddlyspace.com/fractalveg.jpg][http://www.flickr.com/photos/jermy/10134618/]]
+[img[images/fractalveg.jpg][http://www.flickr.com/photos/jermy/10134618/]]
 }}}
-Displays as:
-[img[http://wikitext.tiddlyspace.com/fractalveg.jpg][http://www.flickr.com/photos/jermy/10134618/]]
+Makes the image clickable (works as a link; check out the tooltip as well):
+[img[images/fractalveg.jpg][http://www.flickr.com/photos/jermy/10134618/]]
 !Floating Images with Text
 {{{
-[<img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+[<img[images/fractalveg.jpg]]
 }}}
-[<img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]Displays as.
+[<img[images/fractalveg.jpg]] Floats to the left like here
+@@clear:both;display:block; @@
+To start a new line with "cleared" float like this, put the code below in the beginning of it:
 {{{
 @@clear:both;display:block; @@
 }}}
-Will then clear the float.
-@@clear:both;display:block;Like this@@
+[>img[images/fractalveg.jpg]]Likewise, you can make image float to the right:
 {{{
-[>img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]
+[>img[images/fractalveg.jpg]]
 }}}
-[>img[http://wikitext.tiddlyspace.com/fractalveg.jpg]]Displays as.@@clear:both;display:block; @@
 !See Also
 [[Image Macro]]

--- a/content/MainMenu.tid
+++ b/content/MainMenu.tid
@@ -17,11 +17,11 @@ GettingStarted
 [[RSS|RssFeed]]
 
 <<tiddler Download>>
-
+/%
 <html>
 <a href="http://flattr.com/thing/958386/TiddlyWiki" target="_blank">
-<img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a>
+<img src="//api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a>
 </html>
-
+%/
 ^^[img[favicon.ico]] TiddlyWiki <<version>>
 © 2013 [[UnaMesa|http://www.unamesa.org/]]^^

--- a/content/MarkupPreHead.tid
+++ b/content/MarkupPreHead.tid
@@ -7,7 +7,7 @@ title: MarkupPreHead
 type: text/x-tiddlywiki
 
 <!--{{{-->
-<link rel="shortcut icon" href="/recipes/tiddlywiki-com_public/tiddlers/favicon.ico" />
+<link rel="shortcut icon" href="images/favicon.ico" />
 <link href="/index.xml" rel="alternate"
 	type="application/rss+xml" title="tiddlywiki.com's RSS feed" />
 <!--}}}-->

--- a/content/PluginFormat.tid
+++ b/content/PluginFormat.tid
@@ -11,7 +11,7 @@ It is recommended that [[Plugins]]  start with some standard information in Tidd
 |''Description:''|To demonstrate how to write TiddlyWiki plugins|
 |''Version:''|2.0.2|
 |''Date:''|Jul 12, 2006|
-|''Source:''|http://www.tiddlywiki.com/#ExamplePlugin|
+|''Source:''|https://classic.tiddlywiki.com/#ExamplePlugin|
 |''Author:''|JeremyRuston (jeremy (at) osmosoft (dot) com)|
 |''License:''|[[BSD open source license]]|
 |''~CoreVersion:''|2.1.0|

--- a/content/RssFeed.tid
+++ b/content/RssFeed.tid
@@ -6,4 +6,4 @@ tags: features
 title: RssFeed
 type: text/x-tiddlywiki
 
-TiddlyWiki's RSS feed is available [[here|http://www.tiddlywiki.com/index.xml]]. You can generate an RSS feed for your own TiddlyWiki using the GenerateAnRssFeed option.
+TiddlyWiki's RSS feed is available [[here|./index.xml]]. You can generate an RSS feed for your own TiddlyWiki using the GenerateAnRssFeed option.

--- a/content/SiteUrl.tid
+++ b/content/SiteUrl.tid
@@ -5,4 +5,4 @@ modifier: jermolene
 title: SiteUrl
 type: text/x-tiddlywiki
 
-http://tiddlywiki.com/
+https://classic.tiddlywiki.com/

--- a/content/StartupParameters.tid
+++ b/content/StartupParameters.tid
@@ -8,19 +8,19 @@ type: text/x-tiddlywiki
 
 TiddlyWiki obtains its StartupParameters from the //location// portion of it's URL (the bit after the '#'). At it's simplest, the StartupParameters can list the names of the tiddlers to be opened when the TiddlyWiki is opened:
 {{{
-http://www.tiddlywiki.com/#HelloThere JeremyRuston
+https://classic.tiddlywiki.com/#HelloThere JeremyRuston
 }}}
 In fact, that usage is equivalent to:
 {{{
-http://www.tiddlywiki.com/#open:HelloThere open:JeremyRuston
+https://classic.tiddlywiki.com/#open:HelloThere open:JeremyRuston
 }}}
 The complete list of commands is:
 |!Command |!Description |!Example |
-|open:title |Opens the tiddler with the specified title |http://www.tiddlywiki.com/#open:HelloThere |
-|start:safe |Switches to SafeMode |http://www.tiddlywiki.com/#start:safe |
-|search:text |Performs a search for the specified text |http://www.tiddlywiki.com/#search:jeremy |
-|tag:text |Displays tiddlers tagged with the specified tag |http://www.tiddlywiki.com/#tag:news |
-|newTiddler:title |Opens a new tiddler with the specified title in edit mode |http://www.tiddlywiki.com/#newTiddler:"This is a new tiddler" |
-|newJournal:titleFormat |Opens a new tiddler with the specified [[Date Format String|Date Formats]] |http://www.tiddlywiki.com/#newJournal:"YYYY MMM DD" |
+|open:title |Opens the tiddler with the specified title |https://classic.tiddlywiki.com/#open:HelloThere |
+|start:safe |Switches to SafeMode |https://classic.tiddlywiki.com/#start:safe |
+|search:text |Performs a search for the specified text |https://classic.tiddlywiki.com/#search:jeremy |
+|tag:text |Displays tiddlers tagged with the specified tag |https://classic.tiddlywiki.com/#tag:news |
+|newTiddler:title |Opens a new tiddler with the specified title in edit mode |https://classic.tiddlywiki.com/#newTiddler:"This is a new tiddler" |
+|newJournal:titleFormat |Opens a new tiddler with the specified [[Date Format String|Date Formats]] |https://classic.tiddlywiki.com/#newJournal:"YYYY MMM DD" |
 
 See the details of the underlying ParameterParser for more details.


### PR DESCRIPTION
This is a follow-up to #235 introducing some long-delayed changes and some logical extensions to #235, basically 4 things:

* fix broken links, replace with relative ones where possible
* fix (remove) images' schemas so that https is not broken because of trying to load images via http, remove the outdated flattr thing
* fix paths to some images
* improve text of the "Image Formatting" tiddler (not a final version, but better than it was)