### PR TITLE
Improve code style, increase line height in editor

### DIFF
--- a/shadows/StyleSheetColors.tid
+++ b/shadows/StyleSheetColors.tid
@@ -123,7 +123,7 @@ h2,h3 {border-bottom:1px solid [[ColorPalette::TertiaryLight]];}
 .viewer th, .viewer thead td, .twtable th, .twtable thead td {background:[[ColorPalette::SecondaryMid]]; border:1px solid [[ColorPalette::TertiaryDark]]; color:[[ColorPalette::Background]];}
 .viewer td, .viewer tr, .twtable td, .twtable tr {border:1px solid [[ColorPalette::TertiaryDark]];}
 
-.viewer pre {border:1px solid [[ColorPalette::SecondaryLight]]; background:[[ColorPalette::SecondaryPale]];}
+.viewer pre {background:[[ColorPalette::SecondaryPale]];}
 .viewer code {color:[[ColorPalette::SecondaryDark]];}
 .viewer hr {border:0; border-top:dashed 1px [[ColorPalette::TertiaryDark]]; color:[[ColorPalette::TertiaryDark]];}
 

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -144,9 +144,9 @@ table.listView th, table.listView td, table.listView tr {padding:0 3px 0 3px;}
 * html .viewer pre {width:99%; padding:0 0 1em 0;}
 .viewer pre {padding:0.5em; overflow:auto;}
 pre, code { font-family: monospace, monospace; font-size: 1em; }
-.viewer pre, .viewer code { line-height:1.4em; }
+.viewer pre, .viewer code { line-height: 1.4em; }
 
-.editor {font-size:1.1em;}
+.editor {font-size:1.1em; line-height:1.4em;}
 .editor input, .editor textarea {display:block; width:100%; box-sizing: border-box; font:inherit;}
 .editorFooter {padding:0.25em 0; font-size:.9em;}
 .editorFooter .button {padding-top:0; padding-bottom:0;}

--- a/shadows/StyleSheetLayout.tid
+++ b/shadows/StyleSheetLayout.tid
@@ -131,7 +131,6 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 
 .annotation { padding: 0.5em 0.8em; margin: 0.5em 1px; }
 
-* html .viewer pre {width:99%; padding:0 0 1em 0;}
 .viewer {line-height:1.4em; padding-top:0.5em;}
 .viewer .button {margin:0 0.25em; padding:0 0.25em;}
 .viewer blockquote {line-height:1.5em; padding-left:0.8em;margin-left:2.5em;}
@@ -142,8 +141,10 @@ a.tiddlyLinkNonExisting.shadow {font-weight:bold;}
 table.listView {font-size:0.85em; margin:0.8em 1.0em;}
 table.listView th, table.listView td, table.listView tr {padding:0 3px 0 3px;}
 
-.viewer pre {padding:0.5em; margin-left:0.5em; font-size:1.2em; line-height:1.4em; overflow:auto;}
-.viewer code {font-size:1.2em; line-height:1.4em;}
+* html .viewer pre {width:99%; padding:0 0 1em 0;}
+.viewer pre {padding:0.5em; overflow:auto;}
+pre, code { font-family: monospace, monospace; font-size: 1em; }
+.viewer pre, .viewer code { line-height:1.4em; }
 
 .editor {font-size:1.1em;}
 .editor input, .editor textarea {display:block; width:100%; box-sizing: border-box; font:inherit;}


### PR DESCRIPTION
style adjustments for code blocks:
* remove margin-left
* fix code font size (in different versions of FireFox it's drastically different, and is basically small; the issue and the fix are from [here](http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/))
* remove border

in Chrome:
![image](https://user-images.githubusercontent.com/1131924/62833065-359eb380-bc41-11e9-8309-615360961494.png)
vs
![image](https://user-images.githubusercontent.com/1131924/62833071-4bac7400-bc41-11e9-93fa-72285a0aac90.png)
in FireFox 57:
![image](https://user-images.githubusercontent.com/1131924/62833144-587d9780-bc42-11e9-8e6a-3e9b7449f042.png)
vs
![image](https://user-images.githubusercontent.com/1131924/62833145-5c111e80-bc42-11e9-8984-583ee2599037.png)
(some earlier versions, including Android ones, has this problem of a much worse scale with code almost unreadable)

..and also increase line height in editor for better readability (in my experience, the change is huge, see [here](https://groups.google.com/forum/#!topic/tiddlywikiclassic/0nJ2Fm0lFGM))