### PR TITLE
Update Contribute.tid

### DIFF
--- a/content/Contribute.tid
+++ b/content/Contribute.tid
@@ -1,13 +1,12 @@
 created: 20110211110600000
 creator: psd
-modified: 20110211131000000
-modifier: blaine
+modified: 20130118141000000
+modifier: mkerrigan
 title: Contribute
 type: text/x-tiddlywiki
 
-~TiddlyWiki has an enthusiastic and friendly [[Community|Help and Support]] of people around the world helping to grow and improve it. But there's always more to do and we welcome any offers of assistance. There are many ways that you can help:
-* Testing and [[reporting bugs|https://github.com/TiddlyWiki/TiddlyWiki/issues]] against the core code. Clear, easily reproducible bug reports are incredibly useful and really help the team improve the quality of ~TiddlyWiki
-* [[Contributing code|http://trac.tiddlywiki.org/wiki/ContributingCode]]
-* [[Making translations|https://github.com/TiddlyWiki/translations]]
-* Documentation needs planning, writing and editing, particularly user guide information at http://www.tiddlywiki.org
-If you would like to make a financial contribution, ~TiddlyWiki is owned by the not-for-profit [[UnaMesa Foundation|http://www.unamesa.org/]] which welcomes donations.
+~TiddlyWiki has an enthusiastic and friendly [[Community]] of people around the world helping to grow and improve it. But there's always more to do and we welcome any offers of assistance. There are many ways that you can help:
+* Testing and [[reporting bugs|https://github.com/TiddlyWiki/TiddlyWiki/issues]] against the core code. Clear, easily reproducible bug reports are incredibly useful and help improve the quality of ~TiddlyWiki
+* [[Contributing code|https://github.com/TiddlyWiki/TiddlyWiki]]
+* Making [[translations|Translations]]
+* [[Documentation]]

--- a/content/Contribute.tid
+++ b/content/Contribute.tid
@@ -1,6 +1,6 @@
 created: 20110211110600000
 creator: psd
-modified: 20130118141000000
+modified: 20190825185300000
 modifier: mkerrigan
 title: Contribute
 type: text/x-tiddlywiki
@@ -9,4 +9,4 @@ type: text/x-tiddlywiki
 * Testing and [[reporting bugs|https://github.com/TiddlyWiki/TiddlyWiki/issues]] against the core code. Clear, easily reproducible bug reports are incredibly useful and help improve the quality of ~TiddlyWiki
 * [[Contributing code|https://github.com/TiddlyWiki/TiddlyWiki]]
 * Making [[translations|Translations]]
-* [[Documentation]]
+* Improving [[Documentation]]

--- a/content/Documentation.tid
+++ b/content/Documentation.tid
@@ -1,18 +1,19 @@
 created: 20190825185300000
 creator: mkerrigan
-modified: 20190825185300000
+modified: 20190901202800000
 modifier: mkerrigan
 tags: community help
 title: Documentation
 type: text/x-tiddlywiki
 
-Documentation for ~TiddlyWikiClassic is maintained [[here|https://classic.tiddlywiki.com]].
+Documentation for ~TiddlyWiki Classic is maintained [[here|https://classic.tiddlywiki.com]]. Content tiddlers are stored [[in the core Github repository|https://github.com/TiddlyWiki/TiddlyWiki/tree/master/content]] as separate files and are merged into a single TW (this site) with the [[build tools|https://github.com/TiddlyWiki/tiddlywiki.com]].
 
-Previously documentation was maintained in a ~MediaWiki instance hosted by Osmosoft at [[TiddlyWiki.org]]. [[In 2011|https://groups.google.com/forum/?fromgroups#!topic/tiddlywiki/wAW1pQABu8k]], the content was migrated to a TiddlySpace known as the Community Documentation. A separate DeveloperDocumention was also hosted on TiddlySpace. [[In 2016|https://groups.google.com/forum/#!topic/tiddlyspace/gDqcOXvpiZc]] with ~TiddlySpace discontinued, the Community Documentation and DeveloperDocumention are no longer actively maintained. 
+!Contributing
+Documentation always needs updates and improvements and contributions are welcome. You can contribute by opening a pull request on Github. Feel free to propose changes; to learn more about best practices and specific needs, please ask at the [[community forum|DiscussionForums]].
 
-Currently all documentation is hosted as part of the [[Github repository|https://github.com/TiddlyWiki/tiddlywiki]]. Tiddlers are split into separate files which are then joined together using the TiddlyWiki5 command line tool to produce a single HTML file. See scripts and instructions for testing and building TiddlyWiki and docs for tiddlywiki.com in the [[github.com/TiddlyWiki/tiddlywiki.com/|https://github.com/TiddlyWiki/tiddlywiki.com]] repository.
+!History and other documentation
+Previously documentation was maintained in a ~MediaWiki instance hosted by Osmosoft at tiddlywiki.org. [[In 2011|https://groups.google.com/forum/?fromgroups#!topic/tiddlywiki/wAW1pQABu8k]], the content was migrated to a ~TiddlySpace known as the Community Documentation. A separate ~DeveloperDocumention was also hosted on TiddlySpace. [[In 2016|https://groups.google.com/forum/#!topic/tiddlyspace/gDqcOXvpiZc]] with ~TiddlySpace discontinued, the Community Documentation and ~DeveloperDocumention are no longer actively maintained.
 
-!!!TiddlySpace Backups
+There's also a number of other [[tutorials and guides|TutorialsAndGuides]] created by other ~TiddlyWiki users.
 
-* [[Community Documentation]]
-* [[DeveloperDocumentation]]
+Many seemingly gone docs and other resources in ~TiddlyWikis are in fact available via [[Web Archive|http://web.archive.org/]], for instance [[Community Documentation|http://web.archive.org/web/20161211153445/http://tiddlywiki.tiddlyspace.com/]] and [[Developer Documentation|http://web.archive.org/web/20160810230802/http://tiddlywikidev.tiddlyspace.com/]].

--- a/content/Documentation.tid
+++ b/content/Documentation.tid
@@ -1,0 +1,18 @@
+created: 20190825185300000
+creator: mkerrigan
+modified: 20190825185300000
+modifier: mkerrigan
+tags: community help
+title: Documentation
+type: text/x-tiddlywiki
+
+Documentation for ~TiddlyWikiClassic is maintained [[here|https://classic.tiddlywiki.com]].
+
+Previously documentation was maintained in a ~MediaWiki instance hosted by Osmosoft at [[TiddlyWiki.org]]. [[In 2011|https://groups.google.com/forum/?fromgroups#!topic/tiddlywiki/wAW1pQABu8k]], the content was migrated to a TiddlySpace known as the Community Documentation. A separate DeveloperDocumention was also hosted on TiddlySpace. [[In 2016|https://groups.google.com/forum/#!topic/tiddlyspace/gDqcOXvpiZc]] with ~TiddlySpace discontinued, the Community Documentation and DeveloperDocumention are no longer actively maintained. 
+
+Currently all documentation is hosted as part of the [[Github repository|https://github.com/TiddlyWiki/tiddlywiki]]. Tiddlers are split into separate files which are then joined together using the TiddlyWiki5 command line tool to produce a single HTML file. See scripts and instructions for testing and building TiddlyWiki and docs for tiddlywiki.com in the [[github.com/TiddlyWiki/tiddlywiki.com/|https://github.com/TiddlyWiki/tiddlywiki.com]] repository.
+
+!!!TiddlySpace Backups
+
+* [[Community Documentation]]
+* [[DeveloperDocumentation]]


### PR DESCRIPTION
* Changed reference to [[Help and Support]] to Community.
* Changed contributing code to link directly to Github
* Changed github link to link direct to Translations tiddler (currently no references)
* Removed reference to the tiddlywiki.org documentation to a new Documentation tiddler
* Removed reference to contributing financially to UnaMesa as this is not mentioned on TW5.