### PR TITLE
Create new Setting up saving.tid

### DIFF
--- a/content/Setting%20up%20saving.tid
+++ b/content/Setting%20up%20saving.tid
@@ -1,20 +1,20 @@
-created: 20191015001900000
-creator: mkerrigan
+created: 20191013001900000
+creator: Yakov Litvin
 modified: 20191015001900000
 modifier: mkerrigan
 tags: gettingstarted
 title: Setting up saving
 type: text/x-tiddlywiki
 
-As of [INSERT VERSION], ~TiddlyWiki has a fallback saver. If no saver method is configured, pressing [[SaveChanges]] will display a download dialog. The browser may  prompt for the location to save the file. Select the existing version of the file to replace it. This method works on most major browsers, but does not provide an ideal user experience as it requires manual intervention for each save. 
+Since version 2.8.1, ~TiddlyWiki has a fallback saver. If no saver method is configured, pressing [[SaveChanges]] will display a download dialog. The browser may prompt for the location to save the file. Select the existing version of the file to replace it. This method works on most major browsers, but does not provide an ideal user experience as it requires manual intervention for each save.
 !Browser Plugins
-Using [[Firefox]] in conjunction with a browser plugin provides stable automatic saving. 
-* [[Timini|https://ibnishak.github.io/Timimi/#Installing Timimi]]
-> Extension by Riz for Firefox using native messaging ~APIs allowing it to save standalone ~TiddlyWiki files. It has the advantage of enabling automatic saving from any folder. Note: the platform specific installers are not required if Timini is only being used with ~TiddlyWiki Classic.
+Using Firefox in conjunction with a browser plugin provides stable automatic saving.
+* [[Timimi|https://ibnishak.github.io/Timimi/#Installing Timimi]]
+> Extension by Riz for Firefox that saves standalone ~TiddlyWiki files. It has the advantage of enabling automatic saving from any folder (requires to also install a platform-specific app, uses native messaging ~APIs).
 * [[savetiddlers|https://github.com/buggyj/savetiddlers]]
-> Extension by buggyj for Firefox/Chrome and some Chromium-based browsers such as Opera. Requires the ~TiddlyWiki file be placed in the subfolder within the Downloads folder.
+> Extension by buggyj for Firefox/Chrome and some Chromium-based browsers such as Opera. Requires the ~TiddlyWiki file to be in a subfolder within the Downloads folder.
 * [[file-backups|https://github.com/pmario/file-backups]]
-> Extension by pmario for Firefox and should work in any browser that supports web-extensions. Requires the ~TiddlyWiki file be placed in the Downloads folder. The [[internal backup mechanism|SaveBackups]] must be off.
+> Extension by pmario for Firefox and should work in any browser that supports web-extensions. Requires the ~TiddlyWiki file to be in the Downloads folder. The [[internal backup mechanism|SaveBackups]] must be off.
 !Standalone applications
 Desktop applications provide automatic saving and are not browser dependent. The disadvantage is they don't offer tabs for browsing and require your ~TiddlyWiki file to be a inside a specific folder.
 * [[TiddlyDesktop|https://github.com/Jermolene/TiddlyDesktop]]
@@ -23,14 +23,14 @@ Desktop applications provide automatic saving and are not browser dependent. The
 > Minimalistic approach by nwOkido using bare NW.js and a saver plugin.
 !Serverside applications
 These methods for automatic saving are somewhat advanced, but allow for placing ~TiddlyWiki on a server (local or remote) and generally work on any browser.
-* [[MainTiddlyServer|https://yakovl.github.io/MainTiddlyServer/]] 
-> PHP server by yakov suitable for both local and remote usage.
-* [[tiddly-node-saver|https://github.com/fallwest/tiddly-node-saver]] 
-> node.js server for local usage [insert advantages]
-* [[TiddlyWeb|http://tiddlyweb.com/]] 
-> Python based server, which may be overkill for some.
+* [[MainTiddlyServer|https://yakovl.github.io/MainTiddlyServer/]]
+> PHP server by Yakov Litvin suitable for both local and remote usage.
+* [[tiddly-node-saver|https://github.com/fallwest/tiddly-node-saver]]
+> node.js server for local usage with enhanced load/save file capabilities
+* [[TiddlyWeb|http://tiddlyweb.com/]]
+> Python server with advanced model with multiple users, access control etc.
 !Mobile
-All of these solutions should work in most desktop ~OSs like Windows, Mac or other Unix family OS (Linux, Ubuntu, etc). While some may work on mobile devices, applications written for the respective platform provide a more stable solution. 
+All of solutions above should work in most desktop ~OSs like Windows, Mac or other Unix family OS (Linux, Ubuntu, etc). While some may work on mobile devices, applications written for the respective platform provide are usually simpler to setup and have better performance.
 
 Android
 * Tiddloid
@@ -39,11 +39,12 @@ Android
 > a less mature open source app
 * [[AndTidWiki|https://play.google.com/store/apps/details?id=de.mgsimon.android.andtidwiki]]
 > a closed source app (the first to support TW on Android)
-* MainTiddlyServer 
+* [[MainTiddlyServer|https://yakovl.github.io/MainTiddlyServer/]]
 > Along with [[Server for PHP|https://play.google.com/store/apps/details?id=com.esminis.server.php&hl=en]]. ([[may not work|https://bitbucket.org/esminis/server]] in Android 10)
 iOS
 * [[Quine|https://appadvice.com/app/quine/1228682923]]
 > Paid app by Chris Hunt allowing users to open, edit, and save ~TiddlyWiki files. Works with local storage, Dropbox, and iCloud. Requires iOS 12+.
 !Hosted Options
 Also, you can store your TW(s) on a server:
-[services/hostings] [need explansion]
+* [[TiddlySpot|http://tiddlyspot.com/]], a free hosting for ~TiddlyWiki
+* (this list should be expanded, if you are familiar with Github, you can suggest edits [[here|https://github.com/TiddlyWiki/TiddlyWiki/blob/master/content/Setting%2520up%2520saving.tid]])

--- a/content/Setting%20up%20saving.tid
+++ b/content/Setting%20up%20saving.tid
@@ -22,19 +22,19 @@ Desktop applications provide automatic saving and are not browser dependent. The
 * [[nwTWcSaver|https://github.com/nwOkido/nwTWcSaver]]
 > Minimalistic approach by nwOkido using bare NW.js and a saver plugin.
 !Serverside applications
-These methods for automatic saving are somewhat advanced, but allow for placing ~TiddlyWiki on a server (local or remote) and generally work on any browser.
+These methods for automatic saving are somewhat advanced, but allow for placing ~TiddlyWiki on a server (local or remote) and generally work with any browser.
 * [[MainTiddlyServer|https://yakovl.github.io/MainTiddlyServer/]]
 > PHP server by Yakov Litvin suitable for both local and remote usage.
 * [[tiddly-node-saver|https://github.com/fallwest/tiddly-node-saver]]
-> node.js server for local usage with enhanced load/save file capabilities
+> node.js server by James Westfall for local usage with enhanced load/save file capabilities
 * [[TiddlyWeb|http://tiddlyweb.com/]]
-> Python server with advanced model with multiple users, access control etc.
+> Python server by ~UnaMesa, Osmosoft and Peermore Ltd. with advanced model with multiple users, access control etc.
 !Mobile
-All of solutions above should work in most desktop ~OSs like Windows, Mac or other Unix family OS (Linux, Ubuntu, etc). While some may work on mobile devices, applications written for the respective platform provide are usually simpler to setup and have better performance.
+All of solutions above should work in most desktop ~OSs like Windows, Mac or other Unix family OS (Linux, Ubuntu, etc). While some may work on mobile devices, applications written for the respective platform are usually simpler to setup and have better performance.
 
 Android
-* Tiddloid
-> [[released on GitHub|https://github.com/donmor/Tiddloid/releases]]
+* Tiddloid [[released on GitHub|https://github.com/donmor/Tiddloid/releases]]
+> presumably the best open source solution for the moment
 * Quinoid [[released on GitHub|https://github.com/Marxsal/Quinoid01/releases]]
 > a less mature open source app
 * [[AndTidWiki|https://play.google.com/store/apps/details?id=de.mgsimon.android.andtidwiki]]

--- a/content/Setting%20up%20saving.tid
+++ b/content/Setting%20up%20saving.tid
@@ -6,9 +6,9 @@ tags: gettingstarted
 title: Setting up saving
 type: text/x-tiddlywiki
 
-Since version 2.8.1, ~TiddlyWiki has a fallback saver. If no saver method is configured, pressing [[SaveChanges]] will display a download dialog. The browser may prompt for the location to save the file. Select the existing version of the file to replace it. This method works on most major browsers, but does not provide an ideal user experience as it requires manual intervention for each save.
+Since version 2.8.1, ~TiddlyWiki has a fallback saver. If no saver method is configured, pressing [[SaveChanges]] will display a download dialog. The browser may prompt for the location to save the file. Select the existing version of the file to replace it. This method works on most major browsers, but does not provide an ideal user experience as it requires manual intervention for each save. Below are various tools that remove this routine from saving.
 !Browser Plugins
-Using Firefox in conjunction with a browser plugin provides stable automatic saving.
+Plugins are simple to install and provide smooth user experience, but they are also platform- and browser-specific to some extent.
 * [[Timimi|https://ibnishak.github.io/Timimi/#Installing Timimi]]
 > Extension by Riz for Firefox that saves standalone ~TiddlyWiki files. It has the advantage of enabling automatic saving from any folder (requires to also install a platform-specific app, uses native messaging ~APIs).
 * [[savetiddlers|https://github.com/buggyj/savetiddlers]]

--- a/content/Setting%20up%20saving.tid
+++ b/content/Setting%20up%20saving.tid
@@ -1,0 +1,49 @@
+created: 20191015001900000
+creator: mkerrigan
+modified: 20191015001900000
+modifier: mkerrigan
+tags: gettingstarted
+title: Setting up saving
+type: text/x-tiddlywiki
+
+As of [INSERT VERSION], ~TiddlyWiki has a fallback saver. If no saver method is configured, pressing [[SaveChanges]] will display a download dialog. The browser may  prompt for the location to save the file. Select the existing version of the file to replace it. This method works on most major browsers, but does not provide an ideal user experience as it requires manual intervention for each save. 
+!Browser Plugins
+Using [[Firefox]] in conjunction with a browser plugin provides stable automatic saving. 
+* [[Timini|https://ibnishak.github.io/Timimi/#Installing Timimi]]
+> Extension by Riz for Firefox using native messaging ~APIs allowing it to save standalone ~TiddlyWiki files. It has the advantage of enabling automatic saving from any folder. Note: the platform specific installers are not required if Timini is only being used with ~TiddlyWiki Classic.
+* [[savetiddlers|https://github.com/buggyj/savetiddlers]]
+> Extension by buggyj for Firefox/Chrome and some Chromium-based browsers such as Opera. Requires the ~TiddlyWiki file be placed in the subfolder within the Downloads folder.
+* [[file-backups|https://github.com/pmario/file-backups]]
+> Extension by pmario for Firefox and should work in any browser that supports web-extensions. Requires the ~TiddlyWiki file be placed in the Downloads folder. The [[internal backup mechanism|SaveBackups]] must be off.
+!Standalone applications
+Desktop applications provide automatic saving and are not browser dependent. The disadvantage is they don't offer tabs for browsing and require your ~TiddlyWiki file to be a inside a specific folder.
+* [[TiddlyDesktop|https://github.com/Jermolene/TiddlyDesktop]]
+> Application by Jeremy Ruston for macOS, Windows, and Linux. Based on [[NW.js|https://nwjs.io/]].
+* [[nwTWcSaver|https://github.com/nwOkido/nwTWcSaver]]
+> Minimalistic approach by nwOkido using bare NW.js and a saver plugin.
+!Serverside applications
+These methods for automatic saving are somewhat advanced, but allow for placing ~TiddlyWiki on a server (local or remote) and generally work on any browser.
+* [[MainTiddlyServer|https://yakovl.github.io/MainTiddlyServer/]] 
+> PHP server by yakov suitable for both local and remote usage.
+* [[tiddly-node-saver|https://github.com/fallwest/tiddly-node-saver]] 
+> node.js server for local usage [insert advantages]
+* [[TiddlyWeb|http://tiddlyweb.com/]] 
+> Python based server, which may be overkill for some.
+!Mobile
+All of these solutions should work in most desktop ~OSs like Windows, Mac or other Unix family OS (Linux, Ubuntu, etc). While some may work on mobile devices, applications written for the respective platform provide a more stable solution. 
+
+Android
+* Tiddloid
+> [[released on GitHub|https://github.com/donmor/Tiddloid/releases]]
+* Quinoid [[released on GitHub|https://github.com/Marxsal/Quinoid01/releases]]
+> a less mature open source app
+* [[AndTidWiki|https://play.google.com/store/apps/details?id=de.mgsimon.android.andtidwiki]]
+> a closed source app (the first to support TW on Android)
+* MainTiddlyServer 
+> Along with [[Server for PHP|https://play.google.com/store/apps/details?id=com.esminis.server.php&hl=en]]. ([[may not work|https://bitbucket.org/esminis/server]] in Android 10)
+iOS
+* [[Quine|https://appadvice.com/app/quine/1228682923]]
+> Paid app by Chris Hunt allowing users to open, edit, and save ~TiddlyWiki files. Works with local storage, Dropbox, and iCloud. Requires iOS 12+.
+!Hosted Options
+Also, you can store your TW(s) on a server:
+[services/hostings] [need explansion]

--- a/content/split.recipe
+++ b/content/split.recipe
@@ -287,6 +287,8 @@ tiddler: ServerSide.tid
 
 tiddler: ServicePack2Problems.tid
 
+tiddler: Setting%20up%20saving.tid
+
 tiddler: ShadowTiddlers.tid
 
 tiddler: ShadowTiddlersContent.tid


### PR DESCRIPTION
* In what version did the fallback saver get added?
* There should be a dedicated tiddler for the fallback saver? 
* Long term eliminate the camelcase with Firefox. 
* Timini: Am I describing the current functionality correctly [as of [July 20](https://groups.google.com/d/msg/tiddlywikiclassic/TCuPSb2uMfQ/YG9GJcB9BwAJ)]
* savetiddlers: the documentation states Chrome support is only for TW5?
* savetiddlers: the documention is a bit unclear, must the TiddlyWiki file be placed in a subdirectory?
* SaveBackups.tid: not very helpful. Since the internal backup mechanism only works with TiddlySaver.jar (correct me if I'm wrong), it's a legacy option. This tiddler should contain an explanation, so if people are having issues with saving, they can read a simple explanation about how this option should be set to false.
* tiddly-node-server: what are the advantages?
* Android: should we include Google play links too?
* Hosted Options: eliminate HostedOptions.tid?
* Hosted Options: TiddlySpot
* Hosted Options: Dropbox
* Hosted Options: Github
* not including TiddlySpace since it is not really under active development
* One odd thing I want to note is when I paste this .tid into a blank 2.9.2, it tries to render line 26 (link to MainTiddlyServer) as a link to another tiddler instead of a external link. But when I test this on my 2.6.2 it displays correctly,