### PR TITLE
docs: remove reference to Image Macro

### DIFF
--- a/content/Image%20Formatting.tid
+++ b/content/Image%20Formatting.tid
@@ -38,5 +38,3 @@ To start a new line with "cleared" float like this, put the code below in the be
 {{{
 [>img[images/fractalveg.jpg]]
 }}}
-!See Also
-[[Image Macro]]


### PR DESCRIPTION
Image Macro refers to the [ImageMacroPlugin](http://web.archive.org/web/20150316215114/http://docs.tiddlyspace.com/#ImageMacroPlugin), a TiddlySpace specific plugin not widely used.